### PR TITLE
Implement `open_params` and `get_item_collection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
-# This repo is under development. 
-
 # xcube-stac
+
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![License](https://img.shields.io/github/license/dcs4cop/xcube-smos)](https://github.com/dcs4cop/xcube-smos)
 
-
-`xcube-stac` is a Python package and 
-[xcube plugin](https://xcube.readthedocs.io/en/latest/plugins.html) that adds a 
-[data store](https://xcube.readthedocs.io/en/latest/api.html#data-store-framework) 
-named `stac` to xcube. The data store is used to 
-access data from the [STAC - SpatioTemporal Asset Catalogs](https://stacspec.org/en/).
-
+`xcube-stac` is a Python package and
+[xcube plugin](https://xcube.readthedocs.io/en/latest/plugins.html) that adds a
+[data store](https://xcube.readthedocs.io/en/latest/api.html#data-store-framework)
+named `stac` to xcube. The data store is used to access data from the
+[STAC - SpatioTemporal Asset Catalogs](https://stacspec.org/en/).
 
 ## Setup
 
 ### Installing the xcube-stac plugin from the repository
 
-Installing xcube-cmems directly from the git repository, clone the repository,
+Installing xcube-stac directly from the git repository, clone the repository,
 direct into `xcube-stac`, and follow the steps below:
 
 ```bash
@@ -24,13 +21,15 @@ conda env create -f environment.yml
 conda activate xcube-stac
 pip install .
 ```
-This installs all the dependencies of `xcube-stac` into a fresh conda environment,
-then installs xcube-stac into this environment from the repository.
+
+This installs all the dependencies of `xcube-stac` into a fresh conda
+environment, then installs xcube-stac into this environment from the
+repository.
 
 ## Testing
 
 To run the unit test suite:
-    
+
 ```bash
 pytest
 ```
@@ -48,12 +47,17 @@ To produce an HTML
 pytest --cov-report html --cov=xcube_stac
 ```
 
-### Some notes on the strategy of unittesting:
+### Some notes on the strategy of unittesting
 
-The unit test suite uses [pytest-recording](https://pypi.org/project/pytest-recording/) to mock STAC catalogs. During development an actual HTTP request is performed to a STAC catalog and the responses are saved in `cassettes/**.yaml` files. During testing, only the `cassettes/**.yaml` files are used without an actual HTTP request. During development run
+The unit test suite uses [pytest-recording](https://pypi.org/project/pytest-recording/)
+to mock STAC catalogs. During development an actual HTTP request is performed
+to a STAC catalog and the responses are saved in `cassettes/**.yaml` files.
+During testing, only the `cassettes/**.yaml` files are used without an actual
+HTTP request. During development run
 
 ```bash
 pytest -v -s --record-mode new_episodes
 ```
 
-which saves the responses to `cassettes/**.yaml`. The testing can be then performed as usual.
+which saves the responses to `cassettes/**.yaml`. The testing can be then
+performed as usual.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,41 @@ access data from the [STAC - SpatioTemporal Asset Catalogs](https://stacspec.org
 Installing xcube-cmems directly from the git repository, clone the repository,
 direct into `xcube-stac`, and follow the steps below:
 
-```
-$ conda env create -f environment.yml
-$ conda activate xcube-stac
-$ pip install .
+```bash
+conda env create -f environment.yml
+conda activate xcube-stac
+pip install .
 ```
 This installs all the dependencies of `xcube-stac` into a fresh conda environment,
 then installs xcube-stac into this environment from the repository.
+
+## Testing
+
+To run the unit test suite:
+    
+```bash
+pytest
+```
+
+To analyze test coverage (after installing pytest as above):
+
+```bash
+pytest --cov=xcube_stac
+```
+
+To produce an HTML
+[coverage report](https://pytest-cov.readthedocs.io/en/latest/reporting.html):
+
+```bash
+pytest --cov-report html --cov=xcube_stac
+```
+
+### Some notes on the strategy of unittesting:
+
+The unit test suite uses [pytest-recording](https://pypi.org/project/pytest-recording/) to mock STAC catalogs. During development an actual HTTP request is performed to a STAC catalog and the responses are saved in `cassettes/**.yaml` files. During testing, only the `cassettes/**.yaml` files are used without an actual HTTP request. During development run
+
+```bash
+pytest -v -s --record-mode new_episodes
+```
+
+which saves the responses to `cassettes/**.yaml`. The testing can be then performed as usual.

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   # Required
-  - python>=3.10
+  - python>=3.11
   - pystac
   - pystac-client
   - xarray
@@ -13,4 +13,5 @@ dependencies:
   - black
   - flake8
   - pytest
+  - pytest-cov
   - pytest-recording

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,8 @@ channels:
   - defaults
 dependencies:
   # Required
-  - python>=3.11
+  - python>=3.10
+  - pandas
   - pystac
   - pystac-client
   - xarray

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,11 @@ dependencies:
   # Required
   - python>=3.10
   - pystac
+  - pystac-client
   - xarray
   - xcube
   # for testing
   - black
   - flake8
   - pytest
+  - pytest-recording

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}
 requires-python = ">=3.10"
 dependencies = [
+    "pystac",
+    "pystac-client",
     "xarray",
-    "pystac"
+    "xcube"
 ]
 
 [tool.setuptools.dynamic]
@@ -35,6 +37,7 @@ exclude = [
 dev = [
   "pytest",
   "pytest-cov",
+  "pytest-recording",
   "black",
   "flake8"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,11 +35,11 @@ exclude = [
 
 [project.optional-dependencies]
 dev = [
+  "black",
+  "flake8",
   "pytest",
   "pytest-cov",
-  "pytest-recording",
-  "black",
-  "flake8"
+  "pytest-recording"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,9 @@ keywords = [
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 dependencies = [
+    "pandas",
     "pystac",
     "pystac-client",
     "xarray",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ keywords = [
 ]
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dependencies = [
     "pystac",
     "pystac-client",

--- a/test/cassettes/test_opener/StacDataOpenerTest.test_describe_data.yaml
+++ b/test/cassettes/test_opener/StacDataOpenerTest.test_describe_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '12'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 0a4e232284200ad72c67ee912e80a4079534af08
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320050-CPH
+      X-Timer:
+      - S1714749909.235819,VS0,VE142
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 540d936ced87a52cdd17861b4757844b6bc7b71e
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320056-CPH
+      X-Timer:
+      - S1714749909.439882,VS0,VE153
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_opener/StacDataOpenerTest.test_get_open_data_params_schema.yaml
+++ b/test/cassettes/test_opener/StacDataOpenerTest.test_get_open_data_params_schema.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 946111bff5a656f86ac42d826e730bc3ed27e7a6
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320055-CPH
+      X-Timer:
+      - S1714749910.668303,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - e8716da96d920c901211df1579fabcff085f2dc1
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320042-CPH
+      X-Timer:
+      - S1714749910.704696,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_opener/StacDataOpenerTest.test_open_data.yaml
+++ b/test/cassettes/test_opener/StacDataOpenerTest.test_open_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2878eaf625252e8d7fc064a7d0b2c32f823c3811
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320030-CPH
+      X-Timer:
+      - S1714749910.785993,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 8d0c14f59c09be8cbf0eff7c3439d1c79d0cf539
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320038-CPH
+      X-Timer:
+      - S1714749910.826203,VS0,VE2
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_assert_bbox_intersect.yaml
+++ b/test/cassettes/test_stac/StacTest.test_assert_bbox_intersect.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2129153a3f83638d96f4d419cc674f369142ae19
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320024-CPH
+      X-Timer:
+      - S1714749910.905763,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:09 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:09 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - e968f03199bbeb28663ec7e4d4be1fe4c35bf634
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320041-CPH
+      X-Timer:
+      - S1714749910.951570,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_assert_datetime.yaml
+++ b/test/cassettes/test_stac/StacTest.test_assert_datetime.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - bfb5262ba5750f941b6cd7a6241f9db10a008bc6
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320038-CPH
+      X-Timer:
+      - S1714749910.023210,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - c889a319a8de05ae63d9fa45836b28443602ea87
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320033-CPH
+      X-Timer:
+      - S1714749910.060220,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_do_bboxes_intersect.yaml
+++ b/test/cassettes/test_stac/StacTest.test_do_bboxes_intersect.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Tue, 14 May 2024 09:08:52 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Tue, 14 May 2024 09:13:52 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 676dd71a8ff122cdec17e94a3ab8a088bd54d819
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - D0EE:148AA2:18A7844:1A1CD48:66432132
+      X-Served-By:
+      - cache-fra-eddf8230108-FRA
+      X-Timer:
+      - S1715677732.487448,VS0,VE143
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Tue, 14 May 2024 09:08:52 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Tue, 14 May 2024 09:13:52 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - MISS
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 36989abd8874aadf2e50450fc56334d4fe7c358e
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - 6A22:312E01:32FCAB4:35F3692:66432A24
+      X-Served-By:
+      - cache-fra-eddf8230147-FRA
+      X-Timer:
+      - S1715677733.682246,VS0,VE177
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_get_item_collection.yaml
+++ b/test/cassettes/test_stac/StacTest.test_get_item_collection.yaml
@@ -1,0 +1,812 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - af245cd33397a7a635de1beb424737759ed4ee09
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320021-CPH
+      X-Timer:
+      - S1714749910.138134,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 6a711c62afb006b2616e54011dd2c9a2ba2a5a59
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320032-CPH
+      X-Timer:
+      - S1714749910.188491,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/collection.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n  ],\n
+        \ \"type\": \"Collection\",\n  \"id\": \"zanzibar-collection\",\n  \"title\":
+        \"zanzibar AoI\",\n  \"description\": \"Collection of training labels for
+        zanzibar\",\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n        [\n
+        \         39.28919876472999,\n          -5.878778696206506,\n          39.356865475223195,\n
+        \         -5.722212794937691\n        ]\n      ]\n    },\n    \"temporal\":
+        {\n      \"interval\": [\n        [\n          \"2016-08-28T00:00:00Z\",\n
+        \         null\n        ]\n      ]\n    }\n  },\n  \"version\": \"1.0\",\n
+        \ \"keywords\": [\n    \"demo\"\n  ],\n  \"license\": \"CC-BY-4.0\",\n  \"providers\":
+        [\n    {\n      \"name\": \"Commission for Lands (COLA) ; Revolutionary Government
+        of Zanzibar (RGoZ)\",\n      \"roles\": [\n        \"licensor\"\n      ],\n
+        \     \"url\": \"http://www.zanzibarmapping.com/\"\n    },\n    {\n      \"name\":
+        \"Zanzibar Mapping Initiative\",\n      \"roles\": [\n        \"producer\"\n
+        \     ],\n      \"url\": \"http://www.zanzibarmapping.com/\"\n    },\n    {\n
+        \     \"name\": \"OpenStreetMap\",\n      \"roles\": [\n        \"producer\"\n
+        \     ],\n      \"url\": \"https://www.openstreetmap.org\"\n    },\n    {\n
+        \     \"name\": \"WeRobotics\",\n      \"roles\": [\n        \"processor\"\n
+        \     ],\n      \"url\": \"https://werobotics.org/\"\n    },\n    {\n      \"name\":
+        \"World Bank\",\n      \"roles\": [\n        \"processor\"\n      ],\n      \"url\":
+        \"https://www.worldbank.org\"\n    }\n  ],\n  \"links\": [\n    {\n      \"rel\":
+        \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"parent\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"item\",\n      \"href\": \"znz001.json\"\n    },\n    {\n      \"rel\":
+        \"item\",\n      \"href\": \"znz029.json\"\n    }\n  ]\n}\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '1709'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - '"ddd340bc27c120dd2e43868bcde0510a326a6223dac1b0c47c05100e20d1397e"'
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - d14b623440358fdd80f3979e7f34c3a556d57e76
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CEA048:1E6FBF3:6634FE90
+      X-Served-By:
+      - cache-cph2320054-CPH
+      X-Timer:
+      - S1714749910.221482,VS0,VE153
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/spacenet-buildings/collection.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n  ],\n
+        \ \"type\": \"Collection\",\n  \"id\": \"spacenet-buildings-collection\",\n
+        \ \"title\": \"spacenet-buildings AoI\",\n  \"description\": \"Collection
+        of training labels for spacenet-buildings\",\n  \"extent\": {\n    \"spatial\":
+        {\n      \"bbox\": [\n        [\n          -115.23556259985658,\n          31.234725900085653,\n
+        \         121.66738919996575,\n          49.00558590002751\n        ]\n      ]\n
+        \   },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2016-08-28T00:00:00Z\",\n
+        \         null\n        ]\n      ]\n    }\n  },\n  \"version\": \"1.0\",\n
+        \ \"keywords\": [\n    \"demo\"\n  ],\n  \"license\": \"CC-BY-SA-4.0\",\n
+        \ \"providers\": [\n    {\n      \"name\": \"SpaceNet\",\n      \"roles\":
+        [\n        \"licensor\",\n        \"host\",\n        \"producer\",\n        \"processor\"\n
+        \     ],\n      \"url\": \"https://spacenet.ai\"\n    }\n  ],\n  \"links\":
+        [\n    {\n      \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"../catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_2_Vegas_img2636.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_3_Paris_img1648.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_4_Shanghai_img3344.json\"\n
+        \   }\n  ]\n}\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '1289'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - '"3263faca1f19517d02862736694703cc8519bed9344039cace8aa2c5f9379bcf"'
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 97465dd0702c2c297fc0465a1111902e3b7471fb
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BD44:35E0B5:82172B:890D03:66349397
+      X-Served-By:
+      - cache-cph2320030-CPH
+      X-Timer:
+      - S1714749910.409717,VS0,VE147
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz001.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/label/v1.0.1/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"znz001\",\n  \"type\": \"Feature\",\n  \"bbox\": [\n    39.28919876472999,\n
+        \   -5.743028283012867,\n    39.31302874892266,\n    -5.722212794937691\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          39.28919876472999,\n          -5.743028283012867\n
+        \       ],\n        [\n          39.31302874892266,\n          -5.743028283012867\n
+        \       ],\n        [\n          39.31302874892266,\n          -5.722212794937691\n
+        \       ],\n        [\n          39.28919876472999,\n          -5.722212794937691\n
+        \       ]\n      ]\n    ]\n  },\n  \"assets\": {\n    \"labels\": {\n      \"title\":
+        \"znz001_label\",\n      \"href\": \"https://www.dropbox.com/sh/ct3s1x2a846x3yl/AAARCAOqhcRdoU7ULOb9GJl9a/grid_001.geojson?dl=1\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"znz001_previewcog\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   },\n    \"thumbnail\": {\n      \"title\": \"znz001_thumbnail\",\n      \"href\":
+        \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.png\",\n
+        \     \"type\": \"image/png\"\n    }\n  },\n  \"properties\": {\n    \"datetime\":
+        \"2019-04-23T00:00:00Z\",\n    \"license\": \"CC-BY-4.0\",\n    \"label:properties\":
+        [\n      \"building\",\n      \"condition\"\n    ],\n    \"label:description\":
+        \"building footprints manually  labeled and classified according to building
+        completion status\",\n    \"label:tasks\": [\n      \"segmentation\"\n    ],\n
+        \   \"label:type\": \"vector\",\n    \"label:methods\": [\n      \"manual\"\n
+        \   ],\n    \"version\": \"1\",\n    \"label:classes\": [\n      {\n        \"name\":
+        \"building\",\n        \"classes\": [\n          \"yes\"\n        ]\n      },\n
+        \     {\n        \"name\": \"condition\",\n        \"classes\": [\n          \"Complete\",\n
+        \         \"Incomplete\",\n          \"Foundation\"\n        ]\n      }\n
+        \   ],\n    \"label:overviews\": [\n      {\n        \"property_key\": \"building\",\n
+        \       \"counts\": [\n          {\n            \"name\": \"yes\",\n            \"count\":
+        4440\n          }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n
+        \     \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n
+        \     \"rel\": \"parent\",\n      \"href\": \"collection.json\"\n    },\n
+        \   {\n      \"rel\": \"collection\",\n      \"href\": \"collection.json\"\n
+        \   },\n    {\n      \"rel\": \"source\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"building\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2776'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - '"80ec96bc0acf2e604a03f109bd730426aa82e442d44946231cbe82a531b944f7"'
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 50880485e614fcf90d2ccb2039a8c955a9935670
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - 4110:358461:BBEFF9:C5A505:66349629
+      X-Served-By:
+      - cache-cph2320034-CPH
+      X-Timer:
+      - S1714749911.596900,VS0,VE143
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz029.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/file/v1.0.0/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"znz029\",\n  \"type\": \"Feature\",\n  \"bbox\": [\n    39.3411063109548,\n
+        \   -5.878778696206506,\n    39.356865475223195,\n    -5.851576529338078\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          39.3411063109548,\n          -5.878778696206506\n
+        \       ],\n        [\n          39.3411063109548,\n          -5.851576529338078\n
+        \       ],\n        [\n          39.356865475223195,\n          -5.851576529338078\n
+        \       ],\n        [\n          39.356865475223195,\n          -5.878778696206506\n
+        \       ]\n      ]\n    ]\n  },\n  \"assets\": {\n    \"labels\": {\n      \"title\":
+        \"znz029_label\",\n      \"href\": \"https://www.dropbox.com/sh/ct3s1x2a846x3yl/AADHytc8fSCf3gna0wNAW3lZa/grid_029.geojson?dl=1\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"znz029_previewcog\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   },\n    \"thumbnail\": {\n      \"title\": \"znz029_thumbnail\",\n      \"href\":
+        \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.png\",\n
+        \     \"type\": \"image/png\"\n    }\n  },\n  \"properties\": {\n    \"datetime\":
+        \"2019-04-23T00:00:00Z\",\n    \"license\": \"CC-BY-4.0\",\n    \"label:properties\":
+        [\n      \"building\",\n      \"condition\"\n    ],\n    \"label:description\":
+        \"building footprints manually labeled and classified according to building
+        completion status\",\n    \"label:tasks\": [\n      \"segmentation\"\n    ],\n
+        \   \"label:type\": \"vector\",\n    \"label:methods\": [\n      \"manual\"\n
+        \   ],\n    \"version\": \"1\",\n    \"label:classes\": [\n      {\n        \"name\":
+        \"building\",\n        \"classes\": [\n          \"yes\"\n        ]\n      },\n
+        \     {\n        \"name\": \"condition\",\n        \"classes\": [\n          \"Complete\",\n
+        \         \"Incomplete\",\n          \"Foundation\"\n        ]\n      }\n
+        \   ],\n    \"label:overviews\": [\n      {\n        \"property_key\": \"building\",\n
+        \       \"counts\": [\n          {\n            \"name\": \"yes\",\n            \"count\":
+        1612\n          }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n
+        \     \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n
+        \     \"rel\": \"parent\",\n      \"href\": \"collection.json\"\n    },\n
+        \   {\n      \"rel\": \"collection\",\n      \"href\": \"collection.json\"\n
+        \   },\n    {\n      \"rel\": \"source\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"building\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2774'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:10 GMT
+      ETag:
+      - '"726870312c74ead0b10c3125045c301e8600929684c49447d64c2db72dc779fc"'
+      Expires:
+      - Fri, 03 May 2024 15:30:10 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 7ebfb2eb4299ad07ed1a82a0fa78b02c5ee9c8db
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - B710:26E42A:1C85640:1E0B055:6634FE8F
+      X-Served-By:
+      - cache-cph2320047-CPH
+      X-Timer:
+      - S1714749911.785684,VS0,VE150
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/spacenet-buildings/AOI_2_Vegas_img2636.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/label/v1.0.1/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"AOI_2_Vegas_img2636\",\n  \"type\": \"Feature\",\n  \"bbox\":
+        [\n    -115.23556259985658,\n    36.12654269972625,\n    -115.23412932899998,\n
+        \   36.12829769972975\n  ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n
+        \   \"coordinates\": [\n      [\n        [\n          -115.23556259985658,\n
+        \         36.12654269972625\n        ],\n        [\n          -115.23556259985658,\n
+        \         36.12829769972975\n        ],\n        [\n          -115.23412932899998,\n
+        \         36.12829769972975\n        ],\n        [\n          -115.23412932899998,\n
+        \         36.12654269972625\n        ]\n      ]\n    ]\n  },\n  \"assets\":
+        {\n    \"labels\": {\n      \"title\": \"AOI_2_Vegas_img2636_label\",\n      \"href\":
+        \"https://spacenet-dataset.s3.amazonaws.com/spacenet/SN2_buildings/train/AOI_2_Vegas/geojson_buildings/SN2_buildings_train_AOI_2_Vegas_geojson_buildings_img2636.geojson\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"AOI_2_Vegas_img2636_previewcog\",\n      \"href\": \"https://spacenet-dataset.s3.amazonaws.com/AOIs/AOI_2_Vegas/PS-MS/AOI_2_Vegas_PS-MS_COG.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   }\n  },\n  \"properties\": {\n    \"datetime\": \"2016-08-26T22:41:55Z\",\n
+        \   \"license\": \"CC-BY-SA-4.0\",\n    \"label:properties\": [\n      \"OBJECTID_1\"\n
+        \   ],\n    \"label:description\": \"building footprints manually labeled\",\n
+        \   \"label:tasks\": [\n      \"segmentation\"\n    ],\n    \"label:type\":
+        \"vector\",\n    \"label:methods\": [\n      \"manual\"\n    ],\n    \"version\":
+        \"1\",\n    \"label:classes\": [\n      {\n        \"name\": \"OBJECTID_1\",\n
+        \       \"classes\": [\n          \"0\"\n        ]\n      }\n    ],\n    \"label:overviews\":
+        [\n      {\n        \"property_key\": \"OBJECTID_1\",\n        \"counts\":
+        [\n          {\n            \"name\": \"0\",\n            \"count\": 27\n
+        \         }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n      \"rel\":
+        \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"parent\",\n      \"href\": \"collection.json\"\n    },\n    {\n      \"rel\":
+        \"collection\",\n      \"href\": \"collection.json\"\n    },\n    {\n      \"rel\":
+        \"source\",\n      \"href\": \"https://spacenet-dataset.s3.amazonaws.com/spacenet/SN2_buildings/train/AOI_2_Vegas/PS-RGB/SN2_buildings_train_AOI_2_Vegas_PS-RGB_img2636.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"OBJECTID_1\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2533'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"ce41324ef0ed1993e9becda97e8bd6e7186e24be35178941b14e6f895823f452"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2553e0ede1840cbfa0a865b340042a956f7cb96f
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - 5530:3AEF18:AA92B3:B30ACF:6634FE92
+      X-Served-By:
+      - cache-cph2320025-CPH
+      X-Timer:
+      - S1714749911.994742,VS0,VE151
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/spacenet-buildings/AOI_3_Paris_img1648.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/label/v1.0.1/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"AOI_3_Paris_img1648\",\n  \"type\": \"Feature\",\n  \"bbox\":
+        [\n    2.288201399928881,\n    49.00383090002822,\n    2.289956399928177,\n
+        \   49.00558590002751\n  ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n
+        \   \"coordinates\": [\n      [\n        [\n          2.288201399928881,\n
+        \         49.00383090002822\n        ],\n        [\n          2.289956399928177,\n
+        \         49.00383090002822\n        ],\n        [\n          2.289956399928177,\n
+        \         49.00558590002751\n        ],\n        [\n          2.288201399928881,\n
+        \         49.00558590002751\n        ]\n      ]\n    ]\n  },\n  \"assets\":
+        {\n    \"labels\": {\n      \"title\": \"AOI_3_Paris_img1648_label\",\n      \"href\":
+        \"https://spacenet-dataset.s3.amazonaws.com/spacenet/SN2_buildings/train/AOI_3_Paris/geojson_buildings/SN2_buildings_train_AOI_3_Paris_geojson_buildings_img1648.geojson\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"AOI_3_Paris_img1648_previewcog\",\n      \"href\": \"https://spacenet-dataset.s3.amazonaws.com/AOIs/AOI_3_Paris/PS-MS/AOI_3_Paris_PS-MS_COG.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   }\n  },\n  \"properties\": {\n    \"datetime\": \"2016-08-26T22:41:55Z\",\n
+        \   \"license\": \"CC-BY-SA-4.0\",\n    \"label:properties\": [\n      \"OBJECTID_1\"\n
+        \   ],\n    \"label:description\": \"building footprints manually labeled\",\n
+        \   \"label:tasks\": [\n      \"segmentation\"\n    ],\n    \"label:type\":
+        \"vector\",\n    \"label:methods\": [\n      \"manual\"\n    ],\n    \"version\":
+        \"1\",\n    \"label:classes\": [\n      {\n        \"name\": \"OBJECTID_1\",\n
+        \       \"classes\": [\n          \"0\"\n        ]\n      }\n    ],\n    \"label:overviews\":
+        [\n      {\n        \"property_key\": \"OBJECTID_1\",\n        \"counts\":
+        [\n          {\n            \"name\": \"0\",\n            \"count\": 39\n
+        \         }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n      \"rel\":
+        \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"parent\",\n      \"href\": \"collection.json\"\n    },\n    {\n      \"rel\":
+        \"collection\",\n      \"href\": \"collection.json\"\n    },\n    {\n      \"rel\":
+        \"source\",\n      \"href\": \"https://spacenet-dataset.s3.amazonaws.com/spacenet/SN2_buildings/train/AOI_3_Paris/PS-RGB/SN2_buildings_train_AOI_3_Paris_PS-RGB_img1648.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"OBJECTID_1\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2521'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"64208ffa092e62b99037d93a9865ac76f7b075e742e951fa01a6cc4318f9f91d"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 01d98d0460592a05152a440537e04fb802489148
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - F56A:38D17E:1B64F19:1CD8517:6634CEEC
+      X-Served-By:
+      - cache-cph2320053-CPH
+      X-Timer:
+      - S1714749911.200401,VS0,VE145
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/spacenet-buildings/AOI_4_Shanghai_img3344.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/label/v1.0.1/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"AOI_4_Shanghai_img3344\",\n  \"type\": \"Feature\",\n  \"bbox\":
+        [\n    121.66563419996653,\n    31.234725900085653,\n    121.66738919996575,\n
+        \   31.236480900084874\n  ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n
+        \   \"coordinates\": [\n      [\n        [\n          121.66563419996653,\n
+        \         31.234725900085653\n        ],\n        [\n          121.66563419996653,\n
+        \         31.236480900084874\n        ],\n        [\n          121.66738919996575,\n
+        \         31.236480900084874\n        ],\n        [\n          121.66738919996575,\n
+        \         31.234725900085653\n        ]\n      ]\n    ]\n  },\n  \"assets\":
+        {\n    \"labels\": {\n      \"title\": \"AOI_4_Shanghai_img3344_label\",\n
+        \     \"href\": \"https://spacenet-dataset.s3.amazonaws.com/spacenet/SN2_buildings/train/AOI_4_Shanghai/geojson_buildings/SN2_buildings_train_AOI_4_Shanghai_geojson_buildings_img3344.geojson\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"AOI_4_Shanghai_img3344_previewcog\",\n      \"href\": \"https://spacenet-dataset.s3.amazonaws.com/AOIs/AOI_4_Shanghai/PS-MS/AOI_4_Shanghai_PS-MS_COG.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   }\n  },\n  \"properties\": {\n    \"datetime\": \"2016-08-26T22:41:55Z\",\n
+        \   \"license\": \"CC-BY-SA-4.0\",\n    \"label:properties\": [\n      \"OBJECTID_1\"\n
+        \   ],\n    \"label:description\": \"building footprints manually labeled\",\n
+        \   \"label:tasks\": [\n      \"segmentation\"\n    ],\n    \"label:type\":
+        \"vector\",\n    \"label:methods\": [\n      \"manual\"\n    ],\n    \"version\":
+        \"1\",\n    \"label:classes\": [\n      {\n        \"name\": \"OBJECTID_1\",\n
+        \       \"classes\": [\n          \"0\"\n        ]\n      }\n    ],\n    \"label:overviews\":
+        [\n      {\n        \"property_key\": \"OBJECTID_1\",\n        \"counts\":
+        [\n          {\n            \"name\": \"0\",\n            \"count\": 8\n          }\n
+        \       ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n      \"rel\": \"root\",\n
+        \     \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\": \"parent\",\n
+        \     \"href\": \"collection.json\"\n    },\n    {\n      \"rel\": \"collection\",\n
+        \     \"href\": \"collection.json\"\n    },\n    {\n      \"rel\": \"source\",\n
+        \     \"href\": \"https://spacenet-dataset.s3.amazonaws.com/spacenet/SN2_buildings/train/AOI_4_Shanghai/PS-RGB/SN2_buildings_train_AOI_4_Shanghai_PS-RGB_img3344.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"OBJECTID_1\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2559'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"b013010acfbb8a7c7479cba0a48831d129ecd605ac31316930d1d2f804634dbc"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 0783e06e58e4df777a77e4aadfa00a63ee54831f
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - F11E:2E8F4B:1CEA11C:1E6FCC4:6634FE92
+      X-Served-By:
+      - cache-cph2320055-CPH
+      X-Timer:
+      - S1714749911.390596,VS0,VE171
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_get_item_collection_open_params.yaml
+++ b/test/cassettes/test_stac/StacTest.test_get_item_collection_open_params.yaml
@@ -1,0 +1,524 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '2'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 9a3e23a6b95fde8020458d889b8b41771e818d49
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320052-CPH
+      X-Timer:
+      - S1714749912.652363,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '2'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '22'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 226340d3ca3eebcad0171670ea5692156bc2d4c6
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320050-CPH
+      X-Timer:
+      - S1714749912.695775,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/collection.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n  ],\n
+        \ \"type\": \"Collection\",\n  \"id\": \"zanzibar-collection\",\n  \"title\":
+        \"zanzibar AoI\",\n  \"description\": \"Collection of training labels for
+        zanzibar\",\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n        [\n
+        \         39.28919876472999,\n          -5.878778696206506,\n          39.356865475223195,\n
+        \         -5.722212794937691\n        ]\n      ]\n    },\n    \"temporal\":
+        {\n      \"interval\": [\n        [\n          \"2016-08-28T00:00:00Z\",\n
+        \         null\n        ]\n      ]\n    }\n  },\n  \"version\": \"1.0\",\n
+        \ \"keywords\": [\n    \"demo\"\n  ],\n  \"license\": \"CC-BY-4.0\",\n  \"providers\":
+        [\n    {\n      \"name\": \"Commission for Lands (COLA) ; Revolutionary Government
+        of Zanzibar (RGoZ)\",\n      \"roles\": [\n        \"licensor\"\n      ],\n
+        \     \"url\": \"http://www.zanzibarmapping.com/\"\n    },\n    {\n      \"name\":
+        \"Zanzibar Mapping Initiative\",\n      \"roles\": [\n        \"producer\"\n
+        \     ],\n      \"url\": \"http://www.zanzibarmapping.com/\"\n    },\n    {\n
+        \     \"name\": \"OpenStreetMap\",\n      \"roles\": [\n        \"producer\"\n
+        \     ],\n      \"url\": \"https://www.openstreetmap.org\"\n    },\n    {\n
+        \     \"name\": \"WeRobotics\",\n      \"roles\": [\n        \"processor\"\n
+        \     ],\n      \"url\": \"https://werobotics.org/\"\n    },\n    {\n      \"name\":
+        \"World Bank\",\n      \"roles\": [\n        \"processor\"\n      ],\n      \"url\":
+        \"https://www.worldbank.org\"\n    }\n  ],\n  \"links\": [\n    {\n      \"rel\":
+        \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"parent\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"item\",\n      \"href\": \"znz001.json\"\n    },\n    {\n      \"rel\":
+        \"item\",\n      \"href\": \"znz029.json\"\n    }\n  ]\n}\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '1709'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"ddd340bc27c120dd2e43868bcde0510a326a6223dac1b0c47c05100e20d1397e"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - cc22ef21e3db14d3e15dddbb6667d36e085b5faf
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CEA048:1E6FBF3:6634FE90
+      X-Served-By:
+      - cache-cph2320038-CPH
+      X-Timer:
+      - S1714749912.736014,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/spacenet-buildings/collection.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n  ],\n
+        \ \"type\": \"Collection\",\n  \"id\": \"spacenet-buildings-collection\",\n
+        \ \"title\": \"spacenet-buildings AoI\",\n  \"description\": \"Collection
+        of training labels for spacenet-buildings\",\n  \"extent\": {\n    \"spatial\":
+        {\n      \"bbox\": [\n        [\n          -115.23556259985658,\n          31.234725900085653,\n
+        \         121.66738919996575,\n          49.00558590002751\n        ]\n      ]\n
+        \   },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2016-08-28T00:00:00Z\",\n
+        \         null\n        ]\n      ]\n    }\n  },\n  \"version\": \"1.0\",\n
+        \ \"keywords\": [\n    \"demo\"\n  ],\n  \"license\": \"CC-BY-SA-4.0\",\n
+        \ \"providers\": [\n    {\n      \"name\": \"SpaceNet\",\n      \"roles\":
+        [\n        \"licensor\",\n        \"host\",\n        \"producer\",\n        \"processor\"\n
+        \     ],\n      \"url\": \"https://spacenet.ai\"\n    }\n  ],\n  \"links\":
+        [\n    {\n      \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"../catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_2_Vegas_img2636.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_3_Paris_img1648.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_4_Shanghai_img3344.json\"\n
+        \   }\n  ]\n}\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '1289'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"3263faca1f19517d02862736694703cc8519bed9344039cace8aa2c5f9379bcf"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - c3c9df03d3e56569e368c68e3e1861bfc1b46018
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BD44:35E0B5:82172B:890D03:66349397
+      X-Served-By:
+      - cache-cph2320038-CPH
+      X-Timer:
+      - S1714749912.788174,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz001.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/label/v1.0.1/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"znz001\",\n  \"type\": \"Feature\",\n  \"bbox\": [\n    39.28919876472999,\n
+        \   -5.743028283012867,\n    39.31302874892266,\n    -5.722212794937691\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          39.28919876472999,\n          -5.743028283012867\n
+        \       ],\n        [\n          39.31302874892266,\n          -5.743028283012867\n
+        \       ],\n        [\n          39.31302874892266,\n          -5.722212794937691\n
+        \       ],\n        [\n          39.28919876472999,\n          -5.722212794937691\n
+        \       ]\n      ]\n    ]\n  },\n  \"assets\": {\n    \"labels\": {\n      \"title\":
+        \"znz001_label\",\n      \"href\": \"https://www.dropbox.com/sh/ct3s1x2a846x3yl/AAARCAOqhcRdoU7ULOb9GJl9a/grid_001.geojson?dl=1\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"znz001_previewcog\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   },\n    \"thumbnail\": {\n      \"title\": \"znz001_thumbnail\",\n      \"href\":
+        \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.png\",\n
+        \     \"type\": \"image/png\"\n    }\n  },\n  \"properties\": {\n    \"datetime\":
+        \"2019-04-23T00:00:00Z\",\n    \"license\": \"CC-BY-4.0\",\n    \"label:properties\":
+        [\n      \"building\",\n      \"condition\"\n    ],\n    \"label:description\":
+        \"building footprints manually  labeled and classified according to building
+        completion status\",\n    \"label:tasks\": [\n      \"segmentation\"\n    ],\n
+        \   \"label:type\": \"vector\",\n    \"label:methods\": [\n      \"manual\"\n
+        \   ],\n    \"version\": \"1\",\n    \"label:classes\": [\n      {\n        \"name\":
+        \"building\",\n        \"classes\": [\n          \"yes\"\n        ]\n      },\n
+        \     {\n        \"name\": \"condition\",\n        \"classes\": [\n          \"Complete\",\n
+        \         \"Incomplete\",\n          \"Foundation\"\n        ]\n      }\n
+        \   ],\n    \"label:overviews\": [\n      {\n        \"property_key\": \"building\",\n
+        \       \"counts\": [\n          {\n            \"name\": \"yes\",\n            \"count\":
+        4440\n          }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n
+        \     \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n
+        \     \"rel\": \"parent\",\n      \"href\": \"collection.json\"\n    },\n
+        \   {\n      \"rel\": \"collection\",\n      \"href\": \"collection.json\"\n
+        \   },\n    {\n      \"rel\": \"source\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"building\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2776'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"80ec96bc0acf2e604a03f109bd730426aa82e442d44946231cbe82a531b944f7"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - f64d2eea509a0bc68f45dcc65c4b2d06c818b44b
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - 4110:358461:BBEFF9:C5A505:66349629
+      X-Served-By:
+      - cache-cph2320044-CPH
+      X-Timer:
+      - S1714749912.823200,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz029.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/file/v1.0.0/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"znz029\",\n  \"type\": \"Feature\",\n  \"bbox\": [\n    39.3411063109548,\n
+        \   -5.878778696206506,\n    39.356865475223195,\n    -5.851576529338078\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          39.3411063109548,\n          -5.878778696206506\n
+        \       ],\n        [\n          39.3411063109548,\n          -5.851576529338078\n
+        \       ],\n        [\n          39.356865475223195,\n          -5.851576529338078\n
+        \       ],\n        [\n          39.356865475223195,\n          -5.878778696206506\n
+        \       ]\n      ]\n    ]\n  },\n  \"assets\": {\n    \"labels\": {\n      \"title\":
+        \"znz029_label\",\n      \"href\": \"https://www.dropbox.com/sh/ct3s1x2a846x3yl/AADHytc8fSCf3gna0wNAW3lZa/grid_029.geojson?dl=1\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"znz029_previewcog\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   },\n    \"thumbnail\": {\n      \"title\": \"znz029_thumbnail\",\n      \"href\":
+        \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.png\",\n
+        \     \"type\": \"image/png\"\n    }\n  },\n  \"properties\": {\n    \"datetime\":
+        \"2019-04-23T00:00:00Z\",\n    \"license\": \"CC-BY-4.0\",\n    \"label:properties\":
+        [\n      \"building\",\n      \"condition\"\n    ],\n    \"label:description\":
+        \"building footprints manually labeled and classified according to building
+        completion status\",\n    \"label:tasks\": [\n      \"segmentation\"\n    ],\n
+        \   \"label:type\": \"vector\",\n    \"label:methods\": [\n      \"manual\"\n
+        \   ],\n    \"version\": \"1\",\n    \"label:classes\": [\n      {\n        \"name\":
+        \"building\",\n        \"classes\": [\n          \"yes\"\n        ]\n      },\n
+        \     {\n        \"name\": \"condition\",\n        \"classes\": [\n          \"Complete\",\n
+        \         \"Incomplete\",\n          \"Foundation\"\n        ]\n      }\n
+        \   ],\n    \"label:overviews\": [\n      {\n        \"property_key\": \"building\",\n
+        \       \"counts\": [\n          {\n            \"name\": \"yes\",\n            \"count\":
+        1612\n          }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n
+        \     \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n
+        \     \"rel\": \"parent\",\n      \"href\": \"collection.json\"\n    },\n
+        \   {\n      \"rel\": \"collection\",\n      \"href\": \"collection.json\"\n
+        \   },\n    {\n      \"rel\": \"source\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"building\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2774'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:11 GMT
+      ETag:
+      - '"726870312c74ead0b10c3125045c301e8600929684c49447d64c2db72dc779fc"'
+      Expires:
+      - Fri, 03 May 2024 15:30:11 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 727d385ad20bb0195334f9f83f0d4018b26121e6
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - B710:26E42A:1C85640:1E0B055:6634FE8F
+      X-Served-By:
+      - cache-cph2320029-CPH
+      X-Timer:
+      - S1714749912.862218,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_get_item_collection_searchable_catalog.yaml
+++ b/test/cassettes/test_stac/StacTest.test_get_item_collection_searchable_catalog.yaml
@@ -1,0 +1,3329 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:12 GMT
+      Via:
+      - 1.1 e86025dac63232624d2273c5fd256ce4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - qGi5o7ukIYd8J8GjZZhfOG8-6VXg4Gi1KPKcIshruWUeunlZa7tSmQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501d8-74e0deaa6f8924d8232ba4cd;Parent=7c9417ac0404a43e;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM052EkSvHcEguA=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - ea2c76e1-ea86-4821-a943-33eb94329256
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"bbox": [9.0, 47.0, 10.0, 48.0], "datetime": "2020-03-01T00:00:00Z/2020-03-05T23:59:59Z",
+      "collections": ["sentinel-2-l2a"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '125'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://earth-search.aws.element84.com/v1/search
+  response:
+    body:
+      string: '{"type":"FeatureCollection","stac_version":"1.0.0","stac_extensions":[],"context":{"limit":10,"matched":12,"returned":10},"numberMatched":12,"numberReturned":10,"features":[{"type":"Feature","stac_version":"1.0.0","id":"S2A_32TMT_20200305_0_L2A","properties":{"created":"2022-11-06T11:09:42.477Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.997049,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"T","mgrs:grid_square":"MT","grid:code":"MGRS-32TMT","view:sun_azimuth":161.60219694588,"view:sun_elevation":35.2265497977538,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":0,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.002953,"s2:cloud_shadow_percentage":0,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":99.995941,"s2:high_proba_clouds_percentage":0.001108,"s2:thin_cirrus_percentage":0,"s2:snow_ice_percentage":0,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200305T103021_N0214_R108_T32TMT_20200305T132101.SAFE","s2:generation_time":"2020-03-05T13:21:01.000000Z","s2:datatake_id":"GS2A_20200305T103021_024558_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_SGS__20200305T132101_S20200305T103210_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_SGS__20200305T132101_A024558_T32TMT_N02.14","s2:reflectance_conversion_factor":1.01847806543317,"datetime":"2020-03-05T10:37:41.586000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/e445afeb512384695dbf3f7f227806d0","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T11:09:42.477Z"},"geometry":{"type":"Polygon","coordinates":[[[7.662878883910047,47.8459059875105],[9.130456971519783,47.85361872923358],[9.128044061970888,46.865637260938634],[7.687601396589738,46.85818510451771],[7.662878883910047,47.8459059875105]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TMT_20200305_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/S2A_32TMT_20200305_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32TMT_20200305_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TMT_20200305_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200305_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/5/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[7.662878883910047,46.85818510451771,9.130456971519783,47.85361872923358],"stac_extensions":["https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32TNT_20200305_0_L2A","properties":{"created":"2022-11-06T10:55:09.466Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.994359,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"T","mgrs:grid_square":"NT","grid:code":"MGRS-32TNT","view:sun_azimuth":163.165384571261,"view:sun_elevation":35.4957370939255,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":67.573136,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.005638,"s2:cloud_shadow_percentage":0,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":99.992722,"s2:high_proba_clouds_percentage":0.001637,"s2:thin_cirrus_percentage":0,"s2:snow_ice_percentage":0,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200305T103021_N0214_R108_T32TNT_20200305T132101.SAFE","s2:generation_time":"2020-03-05T13:21:01.000000Z","s2:datatake_id":"GS2A_20200305T103021_024558_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_SGS__20200305T132101_S20200305T103210_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_SGS__20200305T132101_A024558_T32TNT_N02.14","s2:reflectance_conversion_factor":1.01847806543317,"datetime":"2020-03-05T10:37:36.899000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/f89d8cf4cb7120b4b809f64c2f94f302","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T10:55:09.466Z"},"geometry":{"type":"Polygon","coordinates":[[[8.999746010269408,47.85369284462768],[9.69101980741396,47.85161330029973],[9.55886012791897,47.55495681188354],[9.368338261742831,47.135658848147564],[9.352729741458656,47.08767266265497],[9.316093525605385,47.016096406588936],[9.264729613681437,46.90324896761542],[9.251342652573106,46.86543294418706],[8.999750708035261,46.865708871889666],[8.999746010269408,47.85369284462768]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TNT_20200305_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/S2A_32TNT_20200305_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32TNT_20200305_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TNT_20200305_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200305_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/5/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.999746010269408,46.86543294418706,9.69101980741396,47.85369284462768],"stac_extensions":["https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32UMU_20200305_0_L2A","properties":{"created":"2022-11-06T10:15:35.837Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.989337,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"U","mgrs:grid_square":"MU","grid:code":"MGRS-32UMU","view:sun_azimuth":161.715148623316,"view:sun_elevation":34.357882461111,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":0,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.00579,"s2:cloud_shadow_percentage":0,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":99.972987,"s2:high_proba_clouds_percentage":0.01635,"s2:thin_cirrus_percentage":0,"s2:snow_ice_percentage":0.004874,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200305T103021_N0214_R108_T32UMU_20200305T132101.SAFE","s2:generation_time":"2020-03-05T13:21:01.000000Z","s2:datatake_id":"GS2A_20200305T103021_024558_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_SGS__20200305T132101_S20200305T103210_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_SGS__20200305T132101_A024558_T32UMU_N02.14","s2:reflectance_conversion_factor":1.01847806543317,"datetime":"2020-03-05T10:37:27.325000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/1779903867e5df66d5a244742b6a26bb","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T10:15:35.837Z"},"geometry":{"type":"Polygon","coordinates":[[[7.639190643894996,48.74496885512475],[9.132768981529203,48.752927528985374],[9.130235487173156,47.76510167666922],[7.665148177549731,47.75741268155721],[7.639190643894996,48.74496885512475]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UMU_20200305_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/S2A_32UMU_20200305_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32UMU_20200305_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UMU_20200305_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200305_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/5/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[7.639190643894996,47.75741268155721,9.132768981529203,48.752927528985374],"stac_extensions":["https://stac-extensions.github.io/projection/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32UNU_20200305_0_L2A","properties":{"created":"2022-11-06T07:25:48.718Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.999587,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"U","mgrs:grid_square":"NU","grid:code":"MGRS-32UNU","view:sun_azimuth":163.290822294367,"view:sun_elevation":34.6253879805223,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":40.687245,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.000414,"s2:cloud_shadow_percentage":0,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":99.943548,"s2:high_proba_clouds_percentage":0.056039,"s2:thin_cirrus_percentage":0,"s2:snow_ice_percentage":0,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200305T103021_N0214_R108_T32UNU_20200305T132101.SAFE","s2:generation_time":"2020-03-05T13:21:01.000000Z","s2:datatake_id":"GS2A_20200305T103021_024558_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_SGS__20200305T132101_S20200305T103210_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_SGS__20200305T132101_A024558_T32UNU_N02.14","s2:reflectance_conversion_factor":1.01847806543317,"datetime":"2020-03-05T10:37:22.946000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/b0a7b746ee1de01fe3e403819d00f116","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T07:25:48.718Z"},"geometry":{"type":"Polygon","coordinates":[[[8.999741508947045,48.75300400802843],[10.103302080212728,48.74772233422726],[9.65142369046224,47.76332693643577],[8.999746441483952,47.76517556383693],[8.999741508947045,48.75300400802843]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UNU_20200305_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/S2A_32UNU_20200305_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32UNU_20200305_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UNU_20200305_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200305_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/5/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.999741508947045,47.76332693643577,10.103302080212728,48.75300400802843],"stac_extensions":["https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32TMT_20200302_1_L2A","properties":{"created":"2023-10-13T18:30:03.776Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.691963,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"T","mgrs:grid_square":"MT","grid:code":"MGRS-32TMT","view:sun_azimuth":158.814549154224,"view:sun_elevation":33.4900523978486,"s2:degraded_msi_data_percentage":0.0137,"s2:nodata_pixel_percentage":18.382822,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.016622,"s2:cloud_shadow_percentage":0.29136,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0.000016,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":48.589435,"s2:high_proba_clouds_percentage":38.962808,"s2:thin_cirrus_percentage":12.139718,"s2:snow_ice_percentage":0.000037,"s2:product_type":"S2MSI2A","s2:processing_baseline":"05.00","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0500_R065_T32TMT_20230618T173704.SAFE","s2:generation_time":"2023-06-18T17:37:04.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N05.00","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_S2RP_20230618T173704_S20200302T102554_N05.00","s2:granule_id":"S2A_OPER_MSI_L2A_TL_S2RP_20230618T173704_A024515_T32TMT_N05.00","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:44.564000Z","s2:sequence":"1","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/cc4b22fc334a88355d41ed47fa8aabd1","earthsearch:boa_offset_applied":true,"processing:software":{"sentinel2-to-stac":"0.1.1"},"updated":"2023-10-13T18:30:03.776Z"},"geometry":{"type":"Polygon","coordinates":[[[8.12611534325545,47.85036699391149],[7.767654448642307,46.85907504907858],[9.128044061970888,46.865637260938634],[9.130456971519783,47.85361872923358],[8.12611534325545,47.85036699391149]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TMT_20200302_1_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/S2A_32TMT_20200302_1_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32TMT_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TMT_20200302_1_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_1_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/1/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[7.767654448642307,46.85907504907858,9.130456971519783,47.85361872923358],"stac_extensions":["https://stac-extensions.github.io/eo/v1.1.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/projection/v1.1.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32TMT_20200302_0_L2A","properties":{"created":"2022-11-06T10:55:22.682Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":95.748401,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"T","mgrs:grid_square":"MT","grid:code":"MGRS-32TMT","view:sun_azimuth":158.813520062914,"view:sun_elevation":33.4898717506608,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":18.270709,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.001583,"s2:cloud_shadow_percentage":0,"s2:vegetation_percentage":0.001145,"s2:not_vegetated_percentage":0.002659,"s2:water_percentage":0.000049,"s2:unclassified_percentage":0.009016,"s2:medium_proba_clouds_percentage":47.131062,"s2:high_proba_clouds_percentage":39.151004,"s2:thin_cirrus_percentage":9.466336,"s2:snow_ice_percentage":4.237148,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0214_R065_T32TMT_20200302T140838.SAFE","s2:generation_time":"2020-03-02T14:08:38.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_MPS__20200302T140838_S20200302T102554_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_MPS__20200302T140838_A024515_T32TMT_N02.14","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:44.563000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/41de8876424918a0b5e2231d66be26b1","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T10:55:22.682Z"},"geometry":{"type":"Polygon","coordinates":[[[8.124238746842924,47.85035269393901],[9.130456971519783,47.85361872923358],[9.128044061970888,46.865637260938634],[7.76555527720521,46.85905242784824],[8.003566706576096,47.52630531711798],[8.108887183579771,47.80557077859551],[8.124238746842924,47.85035269393901]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TMT_20200302_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/S2A_32TMT_20200302_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32TMT_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TMT_20200302_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/MT/2020/3/S2A_32TMT_20200302_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5300040],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/MT/2020/3/2/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[7.76555527720521,46.85905242784824,9.130456971519783,47.85361872923358],"stac_extensions":["https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32TNT_20200302_1_L2A","properties":{"created":"2023-10-13T18:43:31.831Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.687064,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"T","mgrs:grid_square":"NT","grid:code":"MGRS-32TNT","view:sun_azimuth":160.333137935153,"view:sun_elevation":33.8007933419143,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":0,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.036599,"s2:cloud_shadow_percentage":0.268616,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0.00001,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":88.692778,"s2:high_proba_clouds_percentage":10.642805,"s2:thin_cirrus_percentage":0.351479,"s2:snow_ice_percentage":0.007717,"s2:product_type":"S2MSI2A","s2:processing_baseline":"05.00","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0500_R065_T32TNT_20230618T173704.SAFE","s2:generation_time":"2023-06-18T17:37:04.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N05.00","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_S2RP_20230618T173704_S20200302T102554_N05.00","s2:granule_id":"S2A_OPER_MSI_L2A_TL_S2RP_20230618T173704_A024515_T32TNT_N05.00","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:40.795000Z","s2:sequence":"1","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/c112c9e2cdc6facd050352b97e87176b","earthsearch:boa_offset_applied":true,"processing:software":{"sentinel2-to-stac":"0.1.1"},"updated":"2023-10-13T18:43:31.831Z"},"geometry":{"type":"Polygon","coordinates":[[[8.999746010269408,47.85369284462768],[8.999750708035261,46.865708871889666],[10.440136950695136,46.85664904260366],[10.467263761969436,47.84431622235519],[8.999746010269408,47.85369284462768]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TNT_20200302_1_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/S2A_32TNT_20200302_1_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32TNT_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TNT_20200302_1_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_1_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/1/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.999746010269408,46.85664904260366,10.467263761969436,47.85369284462768],"stac_extensions":["https://stac-extensions.github.io/eo/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/projection/v1.1.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32TNT_20200302_0_L2A","properties":{"created":"2022-11-06T10:50:10.423Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.978003,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"T","mgrs:grid_square":"NT","grid:code":"MGRS-32TNT","view:sun_azimuth":160.332102364081,"view:sun_elevation":33.8006278929008,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":0,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.001058,"s2:cloud_shadow_percentage":0,"s2:vegetation_percentage":0,"s2:not_vegetated_percentage":0.000003,"s2:water_percentage":0,"s2:unclassified_percentage":0,"s2:medium_proba_clouds_percentage":88.935405,"s2:high_proba_clouds_percentage":10.6359,"s2:thin_cirrus_percentage":0.406697,"s2:snow_ice_percentage":0.020936,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0214_R065_T32TNT_20200302T140838.SAFE","s2:generation_time":"2020-03-02T14:08:38.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_MPS__20200302T140838_S20200302T102554_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_MPS__20200302T140838_A024515_T32TNT_N02.14","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:40.794000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/d43540b6be4b8fbbe941753da1f424d5","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T10:50:10.423Z"},"geometry":{"type":"Polygon","coordinates":[[[8.999746010269408,47.85369284462768],[10.467263761969436,47.84431622235519],[10.440136950695136,46.85664904260366],[8.999750708035261,46.865708871889666],[8.999746010269408,47.85369284462768]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TNT_20200302_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/S2A_32TNT_20200302_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32TNT_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32TNT_20200302_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/NT/2020/3/S2A_32TNT_20200302_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5300040],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/T/NT/2020/3/2/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5300040],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.999746010269408,46.85664904260366,10.467263761969436,47.85369284462768],"stac_extensions":["https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32UMU_20200302_1_L2A","properties":{"created":"2023-10-13T18:29:21.247Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.864906,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"U","mgrs:grid_square":"MU","grid:code":"MGRS-32UMU","view:sun_azimuth":158.943635559878,"view:sun_elevation":32.6338038685109,"s2:degraded_msi_data_percentage":0.0194,"s2:nodata_pixel_percentage":42.094469,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.001547,"s2:cloud_shadow_percentage":0.132884,"s2:vegetation_percentage":0.00004,"s2:not_vegetated_percentage":0,"s2:water_percentage":0,"s2:unclassified_percentage":0.00063,"s2:medium_proba_clouds_percentage":47.969699,"s2:high_proba_clouds_percentage":35.635632,"s2:thin_cirrus_percentage":16.259572,"s2:snow_ice_percentage":0,"s2:product_type":"S2MSI2A","s2:processing_baseline":"05.00","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0500_R065_T32UMU_20230618T173704.SAFE","s2:generation_time":"2023-06-18T17:37:04.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N05.00","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_S2RP_20230618T173704_S20200302T102554_N05.00","s2:granule_id":"S2A_OPER_MSI_L2A_TL_S2RP_20230618T173704_A024515_T32UMU_N05.00","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:29.771000Z","s2:sequence":"1","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/59980bf6e701fb2afd7bdfaf5390ae5e","earthsearch:boa_offset_applied":true,"processing:software":{"sentinel2-to-stac":"0.1.1"},"updated":"2023-10-13T18:29:21.247Z"},"geometry":{"type":"Polygon","coordinates":[[[8.46158980134248,48.75174628638449],[8.093981346506181,47.76159948825392],[9.130235487173156,47.76510167666922],[9.132768981529203,48.752927528985374],[8.46158980134248,48.75174628638449]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UMU_20200302_1_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/S2A_32UMU_20200302_1_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32UMU_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UMU_20200302_1_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_1_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/1/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.093981346506181,47.76159948825392,9.132768981529203,48.752927528985374],"stac_extensions":["https://stac-extensions.github.io/eo/v1.1.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.1.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32UMU_20200302_0_L2A","properties":{"created":"2022-11-06T07:28:48.946Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":87.926066,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"U","mgrs:grid_square":"MU","grid:code":"MGRS-32UMU","view:sun_azimuth":158.942614967036,"view:sun_elevation":32.633628278346,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":41.982433,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.034438,"s2:cloud_shadow_percentage":0.000761,"s2:vegetation_percentage":0.000069,"s2:not_vegetated_percentage":0.007509,"s2:water_percentage":0,"s2:unclassified_percentage":0.122523,"s2:medium_proba_clouds_percentage":47.220534,"s2:high_proba_clouds_percentage":35.603142,"s2:thin_cirrus_percentage":5.10239,"s2:snow_ice_percentage":11.908643,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0214_R065_T32UMU_20200302T140838.SAFE","s2:generation_time":"2020-03-02T14:08:38.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_MPS__20200302T140838_S20200302T102554_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_MPS__20200302T140838_A024515_T32UMU_N02.14","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:29.771000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/d98b025f5cac742cada0520bd9ceabce","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T07:28:48.946Z"},"geometry":{"type":"Polygon","coordinates":[[[8.459956976240338,48.75173864614783],[9.132768981529203,48.752927528985374],[9.130235487173156,47.76510167666922],[8.091847731211072,47.76158262475264],[8.21151093710435,48.083797085431065],[8.459956976240338,48.75173864614783]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UMU_20200302_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/S2A_32UMU_20200302_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32UMU_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UMU_20200302_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/MU/2020/3/S2A_32UMU_20200302_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,5400000],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/MU/2020/3/2/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.091847731211072,47.76158262475264,9.132768981529203,48.752927528985374],"stac_extensions":["https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"}],"links":[{"rel":"next","title":"Next
+        page of Items","method":"POST","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","merge":false,"body":{"datetime":"2020-03-01T00:00:00Z/2020-03-05T23:59:59Z","collections":["sentinel-2-l2a"],"bbox":[9,47,10,48],"next":"2020-03-02T10:27:29.771000Z,S2A_32UMU_20200302_0_L2A,sentinel-2-l2a"}},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '214060'
+      Content-Type:
+      - application/geo+json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:12 GMT
+      Via:
+      - 1.1 cb33a7a4640adbb55df3e0d143601558.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hkc5W84c_2X907wj05pd4CJAu9lhIkXl1P-s3sIfJ_rXju4GYp-hoA==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501d8-5b69991c7aafc0ad03cfe13d;Parent=0f0cd672708789c2;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"3442c-e1pIlowugDlZpGTJPEymFlh9yOg"
+      x-amz-apigw-id:
+      - XM058HjAvHcEo3w=
+      x-amzn-Remapped-content-length:
+      - '214060'
+      x-amzn-RequestId:
+      - 29fe7c88-28a9-40d4-aeac-42ca2e8321a2
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"datetime": "2020-03-01T00:00:00Z/2020-03-05T23:59:59Z", "collections":
+      ["sentinel-2-l2a"], "bbox": [9, 47, 10, 48], "next": "2020-03-02T10:27:29.771000Z,S2A_32UMU_20200302_0_L2A,sentinel-2-l2a"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://earth-search.aws.element84.com/v1/search
+  response:
+    body:
+      string: '{"type":"FeatureCollection","stac_version":"1.0.0","stac_extensions":[],"context":{"limit":10,"matched":12,"returned":2},"numberMatched":12,"numberReturned":2,"features":[{"type":"Feature","stac_version":"1.0.0","id":"S2A_32UNU_20200302_1_L2A","properties":{"created":"2023-10-13T18:44:25.781Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":99.521232,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"U","mgrs:grid_square":"NU","grid:code":"MGRS-32UNU","view:sun_azimuth":160.476106394948,"view:sun_elevation":32.9426490397084,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":0,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.000999,"s2:cloud_shadow_percentage":0.453794,"s2:vegetation_percentage":0.009592,"s2:not_vegetated_percentage":0.004628,"s2:water_percentage":0,"s2:unclassified_percentage":0.009758,"s2:medium_proba_clouds_percentage":37.895522,"s2:high_proba_clouds_percentage":49.727982,"s2:thin_cirrus_percentage":11.897724,"s2:snow_ice_percentage":0,"s2:product_type":"S2MSI2A","s2:processing_baseline":"05.00","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0500_R065_T32UNU_20230618T173704.SAFE","s2:generation_time":"2023-06-18T17:37:04.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N05.00","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_S2RP_20230618T173704_S20200302T102554_N05.00","s2:granule_id":"S2A_OPER_MSI_L2A_TL_S2RP_20230618T173704_A024515_T32UNU_N05.00","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:26.417000Z","s2:sequence":"1","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/7bfd3cfbe89a83b72586e3dda408fe1b","earthsearch:boa_offset_applied":true,"processing:software":{"sentinel2-to-stac":"0.1.1"},"updated":"2023-10-13T18:44:25.781Z"},"geometry":{"type":"Polygon","coordinates":[[[8.999741508947045,48.75300400802843],[8.999746441483952,47.76517556383693],[10.464773780997838,47.755827810229526],[10.493255611539013,48.743328407452566],[8.999741508947045,48.75300400802843]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UNU_20200302_1_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/S2A_32UNU_20200302_1_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32UNU_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UNU_20200302_1_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_1_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":-0.1}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/1/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.999741508947045,47.755827810229526,10.493255611539013,48.75300400802843],"stac_extensions":["https://stac-extensions.github.io/eo/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json","https://stac-extensions.github.io/projection/v1.1.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json"],"collection":"sentinel-2-l2a"},{"type":"Feature","stac_version":"1.0.0","id":"S2A_32UNU_20200302_0_L2A","properties":{"created":"2022-11-06T07:25:31.954Z","platform":"sentinel-2a","constellation":"sentinel-2","instruments":["msi"],"eo:cloud_cover":98.233437,"proj:epsg":32632,"mgrs:utm_zone":32,"mgrs:latitude_band":"U","mgrs:grid_square":"NU","grid:code":"MGRS-32UNU","view:sun_azimuth":160.475079616625,"view:sun_elevation":32.9424885245077,"s2:degraded_msi_data_percentage":0,"s2:nodata_pixel_percentage":0,"s2:saturated_defective_pixel_percentage":0,"s2:dark_features_percentage":0.006314,"s2:cloud_shadow_percentage":0.001125,"s2:vegetation_percentage":0.070497,"s2:not_vegetated_percentage":0.027873,"s2:water_percentage":0.000003,"s2:unclassified_percentage":0.412129,"s2:medium_proba_clouds_percentage":37.498102,"s2:high_proba_clouds_percentage":49.737903,"s2:thin_cirrus_percentage":10.997432,"s2:snow_ice_percentage":1.248622,"s2:product_type":"S2MSI2A","s2:processing_baseline":"02.14","s2:product_uri":"S2A_MSIL2A_20200302T102021_N0214_R065_T32UNU_20200302T140838.SAFE","s2:generation_time":"2020-03-02T14:08:38.000000Z","s2:datatake_id":"GS2A_20200302T102021_024515_N02.14","s2:datatake_type":"INS-NOBS","s2:datastrip_id":"S2A_OPER_MSI_L2A_DS_MPS__20200302T140838_S20200302T102554_N02.14","s2:granule_id":"S2A_OPER_MSI_L2A_TL_MPS__20200302T140838_A024515_T32UNU_N02.14","s2:reflectance_conversion_factor":1.01994561687296,"datetime":"2020-03-02T10:27:26.416000Z","s2:sequence":"0","earthsearch:s3_path":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A","earthsearch:payload_id":"roda-sentinel2/workflow-sentinel2-to-stac/379ddd8339cc41f55cfd749bb699e43b","earthsearch:boa_offset_applied":false,"processing:software":{"sentinel2-to-stac":"0.1.0"},"updated":"2022-11-06T07:25:31.954Z"},"geometry":{"type":"Polygon","coordinates":[[[8.999741508947045,48.75300400802843],[10.493255611539013,48.743328407452566],[10.464773780997838,47.755827810229526],[8.999746441483952,47.76517556383693],[8.999741508947045,48.75300400802843]]]},"links":[{"rel":"self","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UNU_20200302_0_L2A"},{"rel":"canonical","href":"s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/S2A_32UNU_20200302_0_L2A.json","type":"application/json"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"},{"rel":"derived_from","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c/items/S2A_32UNU_20200302_0_L1C","type":"application/geo+json"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"collection","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"thumbnail","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items/S2A_32UNU_20200302_0_L2A/thumbnail"}],"assets":{"aot":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/AOT.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B02.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B01.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/granule_metadata.xml","type":"application/xml","roles":["metadata"]},"green":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B03.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B08.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B8A.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B09.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B04.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B05.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B06.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B07.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/SCL.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B11.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/B12.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/thumbnail.jpg","type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/tileinfo_metadata.json","type":"application/json","roles":["metadata"]},"visual":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/TCI.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"roles":["visual"]},"wvp":{"href":"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/U/NU/2020/3/S2A_32UNU_20200302_0_L2A/WVP.tif","type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/AOT.jp2","type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B02.jp2","type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B01.jp2","type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B03.jp2","type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B08.jp2","type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B8A.jp2","type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B09.jp2","type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,499980,0,-60,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B04.jp2","type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B05.jp2","type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B06.jp2","type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B07.jp2","type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/SCL.jp2","type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B11.jp2","type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/B12.jp2","type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/TCI.jp2","type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,499980,0,-10,5400000],"roles":["visual"]},"wvp-jp2":{"href":"s3://sentinel-s2-l2a/tiles/32/U/NU/2020/3/2/0/WVP.jp2","type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,499980,0,-20,5400000],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"bbox":[8.999741508947045,47.755827810229526,10.493255611539013,48.75300400802843],"stac_extensions":["https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/mgrs/v1.0.0/schema.json","https://stac-extensions.github.io/projection/v1.0.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json","https://stac-extensions.github.io/grid/v1.0.0/schema.json","https://stac-extensions.github.io/processing/v1.1.0/schema.json"],"collection":"sentinel-2-l2a"}],"links":[{"rel":"next","title":"Next
+        page of Items","method":"POST","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","merge":false,"body":{"datetime":"2020-03-01T00:00:00Z/2020-03-05T23:59:59Z","collections":["sentinel-2-l2a"],"next":"2020-03-02T10:27:26.416000Z,S2A_32UNU_20200302_0_L2A,sentinel-2-l2a","bbox":[9,47,10,48]}},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '43331'
+      Content-Type:
+      - application/geo+json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:14 GMT
+      Via:
+      - 1.1 d8eef512ab23f23f549b4cd25ac5328c.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _jTn3ygKY_6ciX09-wcn2Urxg4aK-kX43Ewn6Ik2uAbyZhUOVYie4w==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501da-0714e5f56df8945801fc1efb;Parent=59fbe863c05dfcc8;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"a943-TdsobaCdTAhOYG4FP4hoi+Oyj5c"
+      x-amz-apigw-id:
+      - XM06HFhTvHcEXIw=
+      x-amzn-Remapped-content-length:
+      - '43331'
+      x-amzn-RequestId:
+      - 2c2bfed7-d77f-41fd-90c2-fb32224d0c0c
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"datetime": "2020-03-01T00:00:00Z/2020-03-05T23:59:59Z", "collections":
+      ["sentinel-2-l2a"], "next": "2020-03-02T10:27:26.416000Z,S2A_32UNU_20200302_0_L2A,sentinel-2-l2a",
+      "bbox": [9, 47, 10, 48]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+    method: POST
+    uri: https://earth-search.aws.element84.com/v1/search
+  response:
+    body:
+      string: '{"type":"FeatureCollection","stac_version":"1.0.0","stac_extensions":[],"context":{"limit":10,"matched":12,"returned":0},"numberMatched":12,"numberReturned":0,"features":[],"links":[{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"}]}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '275'
+      Content-Type:
+      - application/geo+json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:14 GMT
+      Via:
+      - 1.1 c379418fd6100691807f32f274ebe9ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - hi5dd6CRNOx4foBg2FS9dQSXMl-870q9AayHO-ks7N_X60PFUe-ZwA==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501da-65ac6051273d3ebf7094fbaa;Parent=2c26518eb7bd3744;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"113-INmk1vA1mV5xnSaGV6w1W5CB9KY"
+      x-amz-apigw-id:
+      - XM06PHjhvHcEs8g=
+      x-amzn-Remapped-content-length:
+      - '275'
+      x-amzn-RequestId:
+      - e1abdc40-1339-48ce-9d74-da0e43eb5827
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:15 GMT
+      Via:
+      - 1.1 29051585a13addd312c8ac9d527433c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - dXTwTed-LDE7lfQVbVQ4VEzzIxJxcfg_gwZJMn7qs2T99w5ME0nD8Q==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501db-6e1a9a803cc9b3de4d9ea3c9;Parent=6c51fcc4ea62c576;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM06VFHMvHcEVSg=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 2bb755d8-325f-44c1-ae9e-f5b2ac0745d1
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:16 GMT
+      Via:
+      - 1.1 e86025dac63232624d2273c5fd256ce4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - od4ZRhtk0cEdJJqQZ2X9cKFNW0H0rBXe-HUp7zu-ws3txieGz4NrqA==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501dc-5dd6adae007be3154fe83591;Parent=1e896f68199e545e;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM06bEerPHcEosQ=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - cc038039-c179-4c77-afbb-20bbd07fd6ee
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:16 GMT
+      Via:
+      - 1.1 c379418fd6100691807f32f274ebe9ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - eL9VpJZAysTDudKE-8cxdXxqcLlb84O1f4mO9CxQm41w-FotYoIARg==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501dc-3c6c60901c9adb88426c9f30;Parent=32d9158e4441fb73;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM06hGhHPHcEK6Q=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 22bdeeac-3e51-42a2-9418-21d7e0fa9ecd
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:17 GMT
+      Via:
+      - 1.1 5a5b94c62ea85e0c0d78b169589b08b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - FgN99Y2vuBV25kOEPbM5zagGhh40Bmm10VoW3OPV5xcmhE-6RONgYQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501dd-05d31c7b11b6f64d508009c2;Parent=6d4df2a179dfecd8;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM06oEfGvHcEChg=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - e9fe5ac3-d028-458c-85d6-9658068abf71
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:17 GMT
+      Via:
+      - 1.1 59d92388a3a66e5f245f384a437fa024.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - DzuKO1C5V3p6R6tJW4diqUExKRFIO8VHcIBNNFYz2jVFsn0tzR8TiA==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501dd-4284e9b55be997444eadf831;Parent=2dd508e9558e2396;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM06tF7_vHcEWCA=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 5786bae0-d8c6-4468-b44e-a5f31a27f9a5
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:18 GMT
+      Via:
+      - 1.1 42b60ee17f7593fff72ca1cb725d6c9a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gqmbt-7q_fgP5A5KWWI-zr7SLROrAEwXPxrBW3xoGF58KiwICbbEcA==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501de-7eba6eb47d1e134f3b32ed36;Parent=37ae6c470d6905f2;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM06xFkrvHcEVQg=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - 6643ece5-28f4-421b-9feb-15f397c0fd8a
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:18 GMT
+      Via:
+      - 1.1 2bbba694ff55d664208103e9c25dce14.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - HypZcUHeXHX8Eu3SUE97aoeec9pmbla6IHYAZp45DnlxZrj-l3No-g==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501de-440ffaaa1908215945dd5321;Parent=6fd3a4438fbf42c0;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM060EWYvHcEHPw=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 740dfc51-b3d6-4de3-b304-2e5bf0a37c6b
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:19 GMT
+      Via:
+      - 1.1 8f20db43ba7579b7216cf908572d5054.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - KeG3e9GbfI2f3R7pDLjK_CNVEn2-dZgiu9GEBxGLchli9VivDZbSXQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501df-6d57641250aed75844d9bae0;Parent=34b2b092af4008e5;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM065G1evHcEOyg=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - a962a6ec-ebed-4b4a-8263-63204ac377a2
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:19 GMT
+      Via:
+      - 1.1 29051585a13addd312c8ac9d527433c6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - _aJHrGS32a4dvW59dxTESKsoufiUKOj1Oh9ljrijvwX5LFNzP4NaKg==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501df-39baee2f46f09aa56519d8af;Parent=162a2fe99c1df87d;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM06_GGMPHcENSg=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 26846a5d-7807-4e9a-a488-c361fea8bc2e
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:20 GMT
+      Via:
+      - 1.1 eb83e7e264681d87a86c9b6a2159e502.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6upVsi4968yaf3DAclCYBmnAuwl6uajzZRzuooRCeTRhwChX6NgdwQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e0-6704c24d305a9c176d47dd5d;Parent=5a39c8e5fea29bd1;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM07GEcCPHcEfIQ=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - 35c4039c-c465-4e9d-9b27-1c4c680b2c84
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:20 GMT
+      Via:
+      - 1.1 f797fc0ae68a3abc35e081e46174c9f2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - EBFmK7IxKdsUtUOcBTi8YOzHW8VU5BNo6u6YholZhCSJ5Goc6Lpvig==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e0-4698d95178b31557240c34aa;Parent=572cf7721a3bf320;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM07JHo6vHcEVAg=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 742d4ddd-c888-4edb-b15b-8a734bdf242c
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:20 GMT
+      Via:
+      - 1.1 42b60ee17f7593fff72ca1cb725d6c9a.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - t4eUzrrLNIHs_6r3OCyUOCZOKAJ68XOrW5083ltx3uylQF5uo6Nh9g==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e0-6fb869616e694302615fd000;Parent=11f38f82c1ebee5b;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM07LFqfvHcEGlA=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - f6e1b98e-e48c-4965-aea3-4be4ba0817b6
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:21 GMT
+      Via:
+      - 1.1 ba5b5e2e7fd98c4a472633bc4c1d4480.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 5SFJkvz7asXvdtrGC2wc-rNwvy6PyiMx7SSJ7D8hbt7Xbr7h_p7qkQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e1-69b5bb453aba414a7ed02bb0;Parent=6380c8d26d90211e;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM07OHSavHcEqaQ=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - aec42de5-f68b-4dd7-9ec5-447d07441f9c
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:21 GMT
+      Via:
+      - 1.1 c379418fd6100691807f32f274ebe9ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - GLmdV8pkBuINoGgB6qbkKznsDnCAZ3LBKdJO7t-KqSRC-MrV7Wqnfw==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e1-57e2e7c93eadaf840f9cf025;Parent=61272856c028eaf4;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM07UGySPHcEDkg=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - d0894f1a-424e-42aa-b11e-6833d201160f
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:22 GMT
+      Via:
+      - 1.1 5a5b94c62ea85e0c0d78b169589b08b4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - c26KxgEwnLElvcvwngOp2V74_SFcdsnIJrw_dgOzq5DQFYUjdnofxA==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e2-555f4cc2001e48d17666d851;Parent=4903a4dae0588102;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM07aHATPHcEeNg=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 7898107d-71a3-4c3d-9675-32b71f4b5309
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:23 GMT
+      Via:
+      - 1.1 2bbba694ff55d664208103e9c25dce14.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - C_2d2PtL4pUPHee5d_oF_KIxFdSaYvEKFLNKdqHlTpi6FKNhS9BHzg==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e3-477bdaf248dc1c45129549ae;Parent=2b41000994ea32d7;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM07hEixPHcEPcA=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - 48b4acf1-662b-46b1-8e51-7e47aaf00964
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:23 GMT
+      Via:
+      - 1.1 8f20db43ba7579b7216cf908572d5054.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - PA-iVbJYVDjcM-WZ0V9V9OVvodz3uCZk4FMZr1Pbo9IbA9A0C9NuFg==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e3-103fd83139184a883e13e4ec;Parent=43dbb66062f13f58;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM07nFsIPHcEBsw=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - b8a4f585-ec12-4c28-8bec-6494bb74179f
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:24 GMT
+      Via:
+      - 1.1 c3b74c81fdcb7942211a6c721efa13fc.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6CbIfSBHYE_Em7GdSGUO-8W9Xn_g-CgnUkB5TTKTPD8su85iYGtFfQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e4-7ec844df2b9969831753d2e3;Parent=326afe9bd494de70;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM07uF0SvHcEp5w=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - bd02a544-d822-47a2-9ac7-5c77b43d4ac7
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:24 GMT
+      Via:
+      - 1.1 eab88762658052b4a1e386f8521a38ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - IBwH1RGyB-nImsFboGdAfRkep38jLACBFtqxrmTTryGjMQEksKr7Hw==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e4-0b3e9e5723beb111301fe44d;Parent=515cbcab1be3eda7;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM07yHLgPHcEHcQ=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - e2f087b7-6146-43fc-a120-293c5142538b
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:25 GMT
+      Via:
+      - 1.1 3b02f73dccc5077f1ad544a27a475ed6.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - c3jrq7tscB4z2387GB-oRjmvnPcGXaJL53TebpB2r0TS0fdqH1MaDQ==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e5-58f539721836c427025ced2d;Parent=6afa592d620fa821;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM073HeoPHcEucA=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - eda4bb80-db94-4e56-a553-4cf56b343315
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:25 GMT
+      Via:
+      - 1.1 c2a926ef1bafe1ab239d4761594a8098.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - II7J4-Wu-9avF0VuTh5QgEQp2lNl94vf2pvYKc8PEoR6CFJSbyyDig==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e5-74bd3f111095e1b61020da86;Parent=1802786e874fad43;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM07-FA3PHcEnaA=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 6d4d9942-ebac-4ad5-b366-03ae41373287
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:26 GMT
+      Via:
+      - 1.1 cb33a7a4640adbb55df3e0d143601558.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - KwUi-6ABnafTO9sf3-mYVadBebN93m0T4iuEzrKaYDKwnl6XC41v8Q==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e6-40303d9943f59bff245e91bb;Parent=09d9809d3e6a524d;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM08FE1fPHcEHPw=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - db9affbd-c0da-4d1e-a2f2-24d947a97f9c
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a
+  response:
+    body:
+      string: '{"type":"Collection","id":"sentinel-2-l2a","stac_version":"1.0.0","title":"Sentinel-2
+        Level-2A","description":"Global Sentinel-2 data from the Multispectral Instrument
+        (MSI) onboard Sentinel-2","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"cite-as","href":"https://doi.org/10.5270/S2_-742ikth","title":"Copernicus
+        Sentinel-2 MSI Level-2A (L2A) Bottom-of-Atmosphere Radiance"},{"rel":"license","href":"https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice","title":"proprietary"},{"rel":"parent","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"items","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/items"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/queryables"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a/aggregations"}],"stac_extensions":["https://stac-extensions.github.io/item-assets/v1.0.0/schema.json","https://stac-extensions.github.io/view/v1.0.0/schema.json","https://stac-extensions.github.io/scientific/v1.0.0/schema.json","https://stac-extensions.github.io/raster/v1.1.0/schema.json","https://stac-extensions.github.io/eo/v1.0.0/schema.json"],"item_assets":{"aot":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Aerosol optical thickness
+        (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Blue (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Coastal aerosol (band
+        1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"granule_metadata":{"type":"application/xml","roles":["metadata"]},"green":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Green (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"NIR 3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 1 (band 5)
+        - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 2 (band 6)
+        - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Red edge 3 (band 7)
+        - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Scene classification
+        map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 1 (band 11) -
+        20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"SWIR 2 (band 12) -
+        20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"thumbnail":{"type":"image/jpeg","title":"Thumbnail
+        image","roles":["thumbnail"]},"tileinfo_metadata":{"type":"application/json","roles":["metadata"]},"visual":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"True color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp":{"type":"image/tiff;
+        application=geotiff; profile=cloud-optimized","title":"Water vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]},"aot-jp2":{"type":"image/jp2","title":"Aerosol
+        optical thickness (AOT)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.001,"offset":0}],"roles":["data","reflectance"]},"blue-jp2":{"type":"image/jp2","title":"Blue
+        (band 2) - 10m","eo:bands":[{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"coastal-jp2":{"type":"image/jp2","title":"Coastal
+        aerosol (band 1) - 60m","eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"green-jp2":{"type":"image/jp2","title":"Green
+        (band 3) - 10m","eo:bands":[{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir-jp2":{"type":"image/jp2","title":"NIR
+        1 (band 8) - 10m","eo:bands":[{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir08-jp2":{"type":"image/jp2","title":"NIR
+        2 (band 8A) - 20m","eo:bands":[{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"nir09-jp2":{"type":"image/jp2","title":"NIR
+        3 (band 9) - 60m","eo:bands":[{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026}],"gsd":60,"proj:shape":[1830,1830],"proj:transform":[60,0,399960,0,-60,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":60,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"red-jp2":{"type":"image/jp2","title":"Red
+        (band 4) - 10m","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038}],"gsd":10,"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":10,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge1-jp2":{"type":"image/jp2","title":"Red
+        edge 1 (band 5) - 20m","eo:bands":[{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge2-jp2":{"type":"image/jp2","title":"Red
+        edge 2 (band 6) - 20m","eo:bands":[{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"rededge3-jp2":{"type":"image/jp2","title":"Red
+        edge 3 (band 7) - 20m","eo:bands":[{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"scl-jp2":{"type":"image/jp2","title":"Scene
+        classification map (SCL)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint8","spatial_resolution":20}],"roles":["data","reflectance"]},"swir16-jp2":{"type":"image/jp2","title":"SWIR
+        1 (band 11) - 20m","eo:bands":[{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"swir22-jp2":{"type":"image/jp2","title":"SWIR
+        2 (band 12) - 20m","eo:bands":[{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}],"gsd":20,"proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"scale":0.0001,"offset":0}],"roles":["data","reflectance"]},"visual-jp2":{"type":"image/jp2","title":"True
+        color image","eo:bands":[{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098}],"proj:shape":[10980,10980],"proj:transform":[10,0,399960,0,-10,4900020],"roles":["visual"]},"wvp-jp2":{"type":"image/jp2","title":"Water
+        vapour (WVP)","proj:shape":[5490,5490],"proj:transform":[20,0,399960,0,-20,4900020],"raster:bands":[{"nodata":0,"data_type":"uint16","bits_per_sample":15,"spatial_resolution":20,"unit":"cm","scale":0.001,"offset":0}],"roles":["data","reflectance"]}},"extent":{"spatial":{"bbox":[[-180,-90,180,90]]},"temporal":{"interval":[["2015-06-27T10:25:31.456000Z",null]]}},"license":"proprietary","keywords":["sentinel","earth
+        observation","esa"],"providers":[{"name":"ESA","roles":["producer"],"url":"https://earth.esa.int/web/guest/home"},{"name":"Sinergise","roles":["processor"],"url":"https://registry.opendata.aws/sentinel-2/"},{"name":"AWS","roles":["host"],"url":"http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"},{"name":"Element
+        84","roles":["processor"],"url":"https://element84.com"}],"summaries":{"platform":["sentinel-2a","sentinel-2b"],"constellation":["sentinel-2"],"instruments":["msi"],"gsd":[10,20,60],"view:off_nadir":[0],"sci:doi":["10.5270/s2_-znk9xsj"],"eo:bands":[{"name":"coastal","common_name":"coastal","description":"Coastal
+        aerosol (band 1)","center_wavelength":0.443,"full_width_half_max":0.027},{"name":"blue","common_name":"blue","description":"Blue
+        (band 2)","center_wavelength":0.49,"full_width_half_max":0.098},{"name":"green","common_name":"green","description":"Green
+        (band 3)","center_wavelength":0.56,"full_width_half_max":0.045},{"name":"red","common_name":"red","description":"Red
+        (band 4)","center_wavelength":0.665,"full_width_half_max":0.038},{"name":"rededge1","common_name":"rededge","description":"Red
+        edge 1 (band 5)","center_wavelength":0.704,"full_width_half_max":0.019},{"name":"rededge2","common_name":"rededge","description":"Red
+        edge 2 (band 6)","center_wavelength":0.74,"full_width_half_max":0.018},{"name":"rededge3","common_name":"rededge","description":"Red
+        edge 3 (band 7)","center_wavelength":0.783,"full_width_half_max":0.028},{"name":"nir","common_name":"nir","description":"NIR
+        1 (band 8)","center_wavelength":0.842,"full_width_half_max":0.145},{"name":"nir08","common_name":"nir08","description":"NIR
+        2 (band 8A)","center_wavelength":0.865,"full_width_half_max":0.033},{"name":"nir09","common_name":"nir09","description":"NIR
+        3 (band 9)","center_wavelength":0.945,"full_width_half_max":0.026},{"name":"cirrus","common_name":"cirrus","description":"Cirrus
+        (band 10)","center_wavelength":1.3735,"full_width_half_max":0.075},{"name":"swir16","common_name":"swir16","description":"SWIR
+        1 (band 11)","center_wavelength":1.61,"full_width_half_max":0.143},{"name":"swir22","common_name":"swir22","description":"SWIR
+        2 (band 12)","center_wavelength":2.19,"full_width_half_max":0.242}]}}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '18299'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:27 GMT
+      Via:
+      - 1.1 c2a926ef1bafe1ab239d4761594a8098.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 6XzVrKiWfXI7gJ07G9dBQpxWNpjmMHW-o3IA8Br209-XpIe6tkQ1Ww==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e7-60ac65d6238e39027f159438;Parent=42cbaf328d07e85f;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"477b-Asxhtvc+lqTFG+89C5CkYquEf14"
+      x-amz-apigw-id:
+      - XM08KHD9PHcEXNw=
+      x-amzn-Remapped-content-length:
+      - '18299'
+      x-amzn-RequestId:
+      - 4326fd9f-0377-43c3-9206-52040bdba107
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - earth-search.aws.element84.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://earth-search.aws.element84.com/v1
+  response:
+    body:
+      string: '{"stac_version":"1.0.0","type":"Catalog","id":"earth-search-aws","title":"Earth
+        Search by Element 84","description":"A STAC API of public datasets on AWS","links":[{"rel":"self","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"root","type":"application/json","href":"https://earth-search.aws.element84.com/v1"},{"rel":"conformance","type":"application/json","href":"https://earth-search.aws.element84.com/v1/conformance"},{"rel":"data","type":"application/json","href":"https://earth-search.aws.element84.com/v1/collections"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/search","method":"POST"},{"rel":"aggregate","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregate","method":"GET"},{"rel":"aggregations","type":"application/json","href":"https://earth-search.aws.element84.com/v1/aggregations"},{"rel":"service-desc","type":"application/vnd.oai.openapi","href":"https://earth-search.aws.element84.com/v1/api"},{"rel":"service-doc","type":"text/html","href":"https://earth-search.aws.element84.com/v1/api.html"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","href":"https://earth-search.aws.element84.com/v1/queryables"},{"rel":"server","type":"text/html","href":"https://stac-utils.github.io/stac-server/"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-pre-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-30"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/naip"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/cop-dem-glo-90"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/landsat-c2-l2"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-l1c"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-2-c1-l2a"},{"rel":"child","type":"application/geo+json","href":"https://earth-search.aws.element84.com/v1/collections/sentinel-1-grd"}],"conformsTo":["https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/ogcapi-features#fields","https://api.stacspec.org/v1.0.0/ogcapi-features#sort","https://api.stacspec.org/v1.0.0/ogcapi-features#query","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/item-search#sort","https://api.stacspec.org/v1.0.0/item-search#query","https://api.stacspec.org/v0.3.0/aggregation","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson"]}'
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '3369'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 03 May 2024 15:25:27 GMT
+      Via:
+      - 1.1 eab88762658052b4a1e386f8521a38ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - UdDC_trQe8NottDltkN3aCMPCafF3iBauLY8mNaTdx4XaOmbv785Jg==
+      X-Amz-Cf-Pop:
+      - FRA2-C1
+      X-Amzn-Trace-Id:
+      - Root=1-663501e7-3f77c88f26f6174f0428f36d;Parent=6d06e98e73dd91dc;Sampled=0;lineage=9e2884e9:0
+      X-Cache:
+      - Miss from cloudfront
+      access-control-allow-origin:
+      - '*'
+      etag:
+      - W/"d29-QPs+H0wJLUX32EZKNgzG3k6wfQ8"
+      x-amz-apigw-id:
+      - XM08QFtTvHcEoZw=
+      x-amzn-Remapped-content-length:
+      - '3369'
+      x-amzn-RequestId:
+      - e1ce8e28-4656-4d1c-ba75-1f7735654bda
+      x-powered-by:
+      - Express
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_get_open_data_params_schema.yaml
+++ b/test/cassettes/test_stac/StacTest.test_get_open_data_params_schema.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - c502af8f8686daf09f8bafaf96bd1c77a6730167
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320049-CPH
+      X-Timer:
+      - S1714749928.005785,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '18'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 4bb2db2a031b7ea0ab81a24a0aa9a7f03a7e3c63
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320026-CPH
+      X-Timer:
+      - S1714749928.037855,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_stac/StacTest.test_is_datetime_in_range.yaml
+++ b/test/cassettes/test_stac/StacTest.test_is_datetime_in_range.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Tue, 14 May 2024 09:08:53 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Tue, 14 May 2024 09:13:53 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2cbca05f9d22f301c772d1262935378fd999b79a
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - D0EE:148AA2:18A7844:1A1CD48:66432132
+      X-Served-By:
+      - cache-fra-eddf8230053-FRA
+      X-Timer:
+      - S1715677734.969463,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Tue, 14 May 2024 09:08:54 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Tue, 14 May 2024 09:13:54 GMT
+      Source-Age:
+      - '1'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 4d79d1d040b572d5e021147a378a3e58b1c0a14a
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - 6A22:312E01:32FCAB4:35F3692:66432A24
+      X-Served-By:
+      - cache-fra-eddf8230034-FRA
+      X-Timer:
+      - S1715677734.018500,VS0,VE2
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_describe_data.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_describe_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 7f637283b237c2d2b2fb98b7774bf55dae35a1f4
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320054-CPH
+      X-Timer:
+      - S1714749928.187199,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - debf3efebab98abdfaadf704dbf43d99a1a559f1
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320040-CPH
+      X-Timer:
+      - S1714749928.216734,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_data_ids.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_data_ids.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 14be5efac40aab90771d9626acd1bc448b6bcded
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320049-CPH
+      X-Timer:
+      - S1714749928.273468,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - c5e97eecd0dbaf3a5b93be7b51e1a7dcfdd874ee
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320039-CPH
+      X-Timer:
+      - S1714749928.312487,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_data_opener_ids.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_data_opener_ids.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 61f6709e4d3a89ae6c839ffd09478569b65521ee
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320044-CPH
+      X-Timer:
+      - S1714749928.374867,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 76b94382cbeb9fd3aec4533d48822e962c1c9042
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320034-CPH
+      X-Timer:
+      - S1714749928.413448,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_data_store_params_schema.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_data_store_params_schema.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2b14487b1a1e1fa19e167c9e76a03d2aea3999b2
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320039-CPH
+      X-Timer:
+      - S1714749929.500355,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2aaabc5de3fe39f86d98528f17c1870e10d41bc6
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320027-CPH
+      X-Timer:
+      - S1714749929.532326,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_data_types.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_data_types.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 300d64d18e0ce1b80ea9826129a9bd92452b44cc
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320056-CPH
+      X-Timer:
+      - S1714749929.602171,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 90279fe3048c21ea01ff669c0bf8303a401c7c0a
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320041-CPH
+      X-Timer:
+      - S1714749929.636388,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_data_types_for_data.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_data_types_for_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 4b7cb81caf229cb6f791d1a241a42082b2f53acb
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320029-CPH
+      X-Timer:
+      - S1714749929.708700,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 9494a8411ae039c8600d90f07bbb4c747f7ab739
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320033-CPH
+      X-Timer:
+      - S1714749929.737587,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_item_collection.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_item_collection.yaml
@@ -1,0 +1,524 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 9ba6327d5b687d00dc6fdd939f9f5e7f479f33ba
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320039-CPH
+      X-Timer:
+      - S1714749929.798403,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - e7e762a2fc476f55c11ae63afd4afe92c0780fd7
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320027-CPH
+      X-Timer:
+      - S1714749929.825373,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/collection.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n  ],\n
+        \ \"type\": \"Collection\",\n  \"id\": \"zanzibar-collection\",\n  \"title\":
+        \"zanzibar AoI\",\n  \"description\": \"Collection of training labels for
+        zanzibar\",\n  \"extent\": {\n    \"spatial\": {\n      \"bbox\": [\n        [\n
+        \         39.28919876472999,\n          -5.878778696206506,\n          39.356865475223195,\n
+        \         -5.722212794937691\n        ]\n      ]\n    },\n    \"temporal\":
+        {\n      \"interval\": [\n        [\n          \"2016-08-28T00:00:00Z\",\n
+        \         null\n        ]\n      ]\n    }\n  },\n  \"version\": \"1.0\",\n
+        \ \"keywords\": [\n    \"demo\"\n  ],\n  \"license\": \"CC-BY-4.0\",\n  \"providers\":
+        [\n    {\n      \"name\": \"Commission for Lands (COLA) ; Revolutionary Government
+        of Zanzibar (RGoZ)\",\n      \"roles\": [\n        \"licensor\"\n      ],\n
+        \     \"url\": \"http://www.zanzibarmapping.com/\"\n    },\n    {\n      \"name\":
+        \"Zanzibar Mapping Initiative\",\n      \"roles\": [\n        \"producer\"\n
+        \     ],\n      \"url\": \"http://www.zanzibarmapping.com/\"\n    },\n    {\n
+        \     \"name\": \"OpenStreetMap\",\n      \"roles\": [\n        \"producer\"\n
+        \     ],\n      \"url\": \"https://www.openstreetmap.org\"\n    },\n    {\n
+        \     \"name\": \"WeRobotics\",\n      \"roles\": [\n        \"processor\"\n
+        \     ],\n      \"url\": \"https://werobotics.org/\"\n    },\n    {\n      \"name\":
+        \"World Bank\",\n      \"roles\": [\n        \"processor\"\n      ],\n      \"url\":
+        \"https://www.worldbank.org\"\n    }\n  ],\n  \"links\": [\n    {\n      \"rel\":
+        \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"parent\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n      \"rel\":
+        \"item\",\n      \"href\": \"znz001.json\"\n    },\n    {\n      \"rel\":
+        \"item\",\n      \"href\": \"znz029.json\"\n    }\n  ]\n}\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '1709'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"ddd340bc27c120dd2e43868bcde0510a326a6223dac1b0c47c05100e20d1397e"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '18'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 4692ab5b2bb363bfbf9e3bd67fe337a20b6b6e70
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CEA048:1E6FBF3:6634FE90
+      X-Served-By:
+      - cache-cph2320032-CPH
+      X-Timer:
+      - S1714749929.851981,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/spacenet-buildings/collection.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n  ],\n
+        \ \"type\": \"Collection\",\n  \"id\": \"spacenet-buildings-collection\",\n
+        \ \"title\": \"spacenet-buildings AoI\",\n  \"description\": \"Collection
+        of training labels for spacenet-buildings\",\n  \"extent\": {\n    \"spatial\":
+        {\n      \"bbox\": [\n        [\n          -115.23556259985658,\n          31.234725900085653,\n
+        \         121.66738919996575,\n          49.00558590002751\n        ]\n      ]\n
+        \   },\n    \"temporal\": {\n      \"interval\": [\n        [\n          \"2016-08-28T00:00:00Z\",\n
+        \         null\n        ]\n      ]\n    }\n  },\n  \"version\": \"1.0\",\n
+        \ \"keywords\": [\n    \"demo\"\n  ],\n  \"license\": \"CC-BY-SA-4.0\",\n
+        \ \"providers\": [\n    {\n      \"name\": \"SpaceNet\",\n      \"roles\":
+        [\n        \"licensor\",\n        \"host\",\n        \"producer\",\n        \"processor\"\n
+        \     ],\n      \"url\": \"https://spacenet.ai\"\n    }\n  ],\n  \"links\":
+        [\n    {\n      \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"parent\",\n      \"href\": \"../catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_2_Vegas_img2636.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_3_Paris_img1648.json\"\n
+        \   },\n    {\n      \"rel\": \"item\",\n      \"href\": \"AOI_4_Shanghai_img3344.json\"\n
+        \   }\n  ]\n}\n"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '1289'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"3263faca1f19517d02862736694703cc8519bed9344039cace8aa2c5f9379bcf"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '18'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 2f73e7d63ed226e827e7297687da51ccdb505510
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BD44:35E0B5:82172B:890D03:66349397
+      X-Served-By:
+      - cache-cph2320028-CPH
+      X-Timer:
+      - S1714749929.883447,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz001.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/label/v1.0.1/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"znz001\",\n  \"type\": \"Feature\",\n  \"bbox\": [\n    39.28919876472999,\n
+        \   -5.743028283012867,\n    39.31302874892266,\n    -5.722212794937691\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          39.28919876472999,\n          -5.743028283012867\n
+        \       ],\n        [\n          39.31302874892266,\n          -5.743028283012867\n
+        \       ],\n        [\n          39.31302874892266,\n          -5.722212794937691\n
+        \       ],\n        [\n          39.28919876472999,\n          -5.722212794937691\n
+        \       ]\n      ]\n    ]\n  },\n  \"assets\": {\n    \"labels\": {\n      \"title\":
+        \"znz001_label\",\n      \"href\": \"https://www.dropbox.com/sh/ct3s1x2a846x3yl/AAARCAOqhcRdoU7ULOb9GJl9a/grid_001.geojson?dl=1\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"znz001_previewcog\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   },\n    \"thumbnail\": {\n      \"title\": \"znz001_thumbnail\",\n      \"href\":
+        \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.png\",\n
+        \     \"type\": \"image/png\"\n    }\n  },\n  \"properties\": {\n    \"datetime\":
+        \"2019-04-23T00:00:00Z\",\n    \"license\": \"CC-BY-4.0\",\n    \"label:properties\":
+        [\n      \"building\",\n      \"condition\"\n    ],\n    \"label:description\":
+        \"building footprints manually  labeled and classified according to building
+        completion status\",\n    \"label:tasks\": [\n      \"segmentation\"\n    ],\n
+        \   \"label:type\": \"vector\",\n    \"label:methods\": [\n      \"manual\"\n
+        \   ],\n    \"version\": \"1\",\n    \"label:classes\": [\n      {\n        \"name\":
+        \"building\",\n        \"classes\": [\n          \"yes\"\n        ]\n      },\n
+        \     {\n        \"name\": \"condition\",\n        \"classes\": [\n          \"Complete\",\n
+        \         \"Incomplete\",\n          \"Foundation\"\n        ]\n      }\n
+        \   ],\n    \"label:overviews\": [\n      {\n        \"property_key\": \"building\",\n
+        \       \"counts\": [\n          {\n            \"name\": \"yes\",\n            \"count\":
+        4440\n          }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n
+        \     \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n
+        \     \"rel\": \"parent\",\n      \"href\": \"collection.json\"\n    },\n
+        \   {\n      \"rel\": \"collection\",\n      \"href\": \"collection.json\"\n
+        \   },\n    {\n      \"rel\": \"source\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5afeda152b6a08001185f11a/0/5afeda152b6a08001185f11b.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"building\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2776'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"80ec96bc0acf2e604a03f109bd730426aa82e442d44946231cbe82a531b944f7"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '18'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 468daa939d0ce93abdec62e3f27ee1e781d31905
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - 4110:358461:BBEFF9:C5A505:66349629
+      X-Served-By:
+      - cache-cph2320048-CPH
+      X-Timer:
+      - S1714749929.933947,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz029.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"stac_extensions\": [\n
+        \   \"https://stac-extensions.github.io/file/v1.0.0/schema.json\",\n    \"https://stac-extensions.github.io/version/v1.0.0/schema.json\"\n
+        \ ],\n  \"id\": \"znz029\",\n  \"type\": \"Feature\",\n  \"bbox\": [\n    39.3411063109548,\n
+        \   -5.878778696206506,\n    39.356865475223195,\n    -5.851576529338078\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          39.3411063109548,\n          -5.878778696206506\n
+        \       ],\n        [\n          39.3411063109548,\n          -5.851576529338078\n
+        \       ],\n        [\n          39.356865475223195,\n          -5.851576529338078\n
+        \       ],\n        [\n          39.356865475223195,\n          -5.878778696206506\n
+        \       ]\n      ]\n    ]\n  },\n  \"assets\": {\n    \"labels\": {\n      \"title\":
+        \"znz029_label\",\n      \"href\": \"https://www.dropbox.com/sh/ct3s1x2a846x3yl/AADHytc8fSCf3gna0wNAW3lZa/grid_029.geojson?dl=1\",\n
+        \     \"type\": \"application/geo+json\"\n    },\n    \"raster\": {\n      \"title\":
+        \"znz029_previewcog\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\"\n
+        \   },\n    \"thumbnail\": {\n      \"title\": \"znz029_thumbnail\",\n      \"href\":
+        \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.png\",\n
+        \     \"type\": \"image/png\"\n    }\n  },\n  \"properties\": {\n    \"datetime\":
+        \"2019-04-23T00:00:00Z\",\n    \"license\": \"CC-BY-4.0\",\n    \"label:properties\":
+        [\n      \"building\",\n      \"condition\"\n    ],\n    \"label:description\":
+        \"building footprints manually labeled and classified according to building
+        completion status\",\n    \"label:tasks\": [\n      \"segmentation\"\n    ],\n
+        \   \"label:type\": \"vector\",\n    \"label:methods\": [\n      \"manual\"\n
+        \   ],\n    \"version\": \"1\",\n    \"label:classes\": [\n      {\n        \"name\":
+        \"building\",\n        \"classes\": [\n          \"yes\"\n        ]\n      },\n
+        \     {\n        \"name\": \"condition\",\n        \"classes\": [\n          \"Complete\",\n
+        \         \"Incomplete\",\n          \"Foundation\"\n        ]\n      }\n
+        \   ],\n    \"label:overviews\": [\n      {\n        \"property_key\": \"building\",\n
+        \       \"counts\": [\n          {\n            \"name\": \"yes\",\n            \"count\":
+        1612\n          }\n        ]\n      }\n    ]\n  },\n  \"links\": [\n    {\n
+        \     \"rel\": \"root\",\n      \"href\": \"../catalog.json\"\n    },\n    {\n
+        \     \"rel\": \"parent\",\n      \"href\": \"collection.json\"\n    },\n
+        \   {\n      \"rel\": \"collection\",\n      \"href\": \"collection.json\"\n
+        \   },\n    {\n      \"rel\": \"source\",\n      \"href\": \"https://oin-hotosm.s3.amazonaws.com/5ae242fd0b093000130afd38/0/5ae242fd0b093000130afd39.tif\",\n
+        \     \"title\": \"The source imagery these building labels were derived from\",\n
+        \     \"label:assets\": [\n        \"building\"\n      ]\n    }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '2774'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:28 GMT
+      ETag:
+      - '"726870312c74ead0b10c3125045c301e8600929684c49447d64c2db72dc779fc"'
+      Expires:
+      - Fri, 03 May 2024 15:30:28 GMT
+      Source-Age:
+      - '18'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 38ecb643410c04a2e3aa829e19aeeccfba62acc0
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - B710:26E42A:1C85640:1E0B055:6634FE8F
+      X-Served-By:
+      - cache-cph2320038-CPH
+      X-Timer:
+      - S1714749929.972906,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_open_data_params_schema.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_open_data_params_schema.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 441d80997bf39fb2f2cc7425e54a9130a245059a
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320035-CPH
+      X-Timer:
+      - S1714749929.060379,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '19'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - b7b4c7d78fe782beb00c1b4e22c4a0a99d3c8814
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320045-CPH
+      X-Timer:
+      - S1714749929.090788,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_get_search_params_schema.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_get_search_params_schema.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 51bd0e28674149f8a6511e7220709c5d707cd6b8
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320046-CPH
+      X-Timer:
+      - S1714749929.174729,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 674f86cc5615b1a123279ed51a7cc33bc98cd2dc
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320054-CPH
+      X-Timer:
+      - S1714749929.221389,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_has_data.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_has_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 0150f4b8fb35d2d65a21a67da291495921fa6c19
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320041-CPH
+      X-Timer:
+      - S1714749929.285087,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 8db1a2730a5dba7c9c1415ee2f04a8305228051c
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320059-CPH
+      X-Timer:
+      - S1714749929.324218,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_open_data.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_open_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '2'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - abe4f0d57fc2868cde252d36a04a95c3849e3e1e
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320041-CPH
+      X-Timer:
+      - S1714749929.388680,VS0,VE0
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 5c412d7c8ec5bd27cbb15106cd2700a64e41477b
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320044-CPH
+      X-Timer:
+      - S1714749929.425456,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_open_data_wrong_opener_id.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_open_data_wrong_opener_id.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - d6adf9a9e278c1e819b7887b5870e096b3f55964
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320028-CPH
+      X-Timer:
+      - S1714749929.496967,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 86eaab36e30b33c3f87acd55cf7fe82de73a128c
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320022-CPH
+      X-Timer:
+      - S1714749930.537121,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/cassettes/test_store/StacDataStoreTest.test_search_data.yaml
+++ b/test/cassettes/test_store/StacDataStoreTest.test_search_data.yaml
@@ -1,0 +1,150 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '236'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - W/"acb7a8d6636e24e32f4018c14f1c4ff418a82567b2746560f9eae6ad97a48a54"
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 02e8e14da5f5ffad99ec2622434aceeec44f85f3
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F67:1E6FB08:6634FE90
+      X-Served-By:
+      - cache-cph2320051-CPH
+      X-Timer:
+      - S1714749930.603023,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - raw.githubusercontent.com
+      User-Agent:
+      - Python-urllib/3.12
+    method: GET
+    uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.0.0-rc.1\",\n  \"type\": \"Catalog\",\n
+        \ \"id\": \"label_extension_demo\",\n  \"title\": \"label extension demo\",\n
+        \ \"description\": \"Sample ML training data labels in the STAC format\",\n
+        \ \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\": \"./catalog.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"zanzibar/collection.json\"\n
+        \   },\n    {\n      \"rel\": \"child\",\n      \"href\": \"spacenet-buildings/collection.json\"\n
+        \   }\n  ]\n}"
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - max-age=300
+      Connection:
+      - close
+      Content-Length:
+      - '436'
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - text/plain; charset=utf-8
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      Date:
+      - Fri, 03 May 2024 15:25:29 GMT
+      ETag:
+      - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
+      Expires:
+      - Fri, 03 May 2024 15:30:29 GMT
+      Source-Age:
+      - '20'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Authorization,Accept-Encoding,Origin
+      Via:
+      - 1.1 varnish
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Content-Type-Options:
+      - nosniff
+      X-Fastly-Request-ID:
+      - 0ee4551d52e42dd8d6e2086c23c5481170380f35
+      X-Frame-Options:
+      - deny
+      X-GitHub-Request-Id:
+      - BACE:2E8F4B:1CE9F92:1E6FB29:6634FE90
+      X-Served-By:
+      - cache-cph2320055-CPH
+      X-Timer:
+      - S1714749930.647178,VS0,VE1
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/test/test_opener.py
+++ b/test/test_opener.py
@@ -20,11 +20,12 @@
 # SOFTWARE.
 
 import unittest
-import pytest
 
+import pytest
 from xcube.util.jsonschema import JsonObjectSchema
-from xcube_stac.store import StacDataOpener
+
 from xcube_stac.stac import Stac
+from xcube_stac.store import StacDataOpener
 
 
 class StacDataOpenerTest(unittest.TestCase):

--- a/test/test_opener.py
+++ b/test/test_opener.py
@@ -20,6 +20,7 @@
 # SOFTWARE.
 
 import unittest
+import pytest
 
 from xcube.util.jsonschema import JsonObjectSchema
 from xcube_stac.store import StacDataOpener
@@ -28,25 +29,38 @@ from xcube_stac.stac import Stac
 
 class StacDataOpenerTest(unittest.TestCase):
 
-    def setUp(self) -> None:
-        stac_instance = Stac("url")
-        self.opener = StacDataOpener(stac_instance)
+    def setUp(self):
+        self.url = (
+            "https://raw.githubusercontent.com/stac-extensions/"
+            "label/main/examples/multidataset/catalog.json"
+        )
+        self.data_id = "zanzibar-collection/znz001/raster"
 
+    @pytest.mark.vcr()
     def test_get_open_data_params_schema(self):
-        schema = self.opener.get_open_data_params_schema()
+        opener = StacDataOpener(Stac(self.url))
+        schema = opener.get_open_data_params_schema()
         self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertIn("variable_names", schema.properties)
+        self.assertIn("time_range", schema.properties)
+        self.assertIn("bbox", schema.properties)
+        self.assertIn("collections", schema.properties)
 
+    @pytest.mark.vcr()
     def test_open_data(self):
+        opener = StacDataOpener(Stac(self.url))
         with self.assertRaises(NotImplementedError) as cm:
-            self.opener.open_data("data_id1")
+            opener.open_data(self.data_id)
         self.assertEqual(
             "open_data() operation is not supported yet",
             f"{cm.exception}",
         )
 
+    @pytest.mark.vcr()
     def test_describe_data(self):
+        opener = StacDataOpener(Stac(self.url))
         with self.assertRaises(NotImplementedError) as cm:
-            self.opener.describe_data("data_id1")
+            opener.describe_data(self.data_id)
         self.assertEqual(
             "describe_data() operation is not supported yet",
             f"{cm.exception}",

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -22,6 +22,7 @@
 import unittest
 
 from xcube.util.extension import ExtensionRegistry
+
 from xcube_stac.plugin import init_plugin
 
 

--- a/test/test_stac.py
+++ b/test/test_stac.py
@@ -20,16 +20,183 @@
 # SOFTWARE.
 
 import unittest
+import pytest
+from pystac import ItemCollection
 from xcube_stac.stac import Stac
+from xcube.util.jsonschema import JsonObjectSchema
 
 
 class StacTest(unittest.TestCase):
 
-    def test_open_data(self):
-        stac_instance = Stac("url")
-        with self.assertRaises(NotImplementedError) as cm:
-            stac_instance.open_data("data_id1")
-        self.assertEqual(
-            "open_data() operation is not supported yet",
-            f"{cm.exception}",
+    def setUp(self):
+        self.url_nonsearchable = (
+            "https://raw.githubusercontent.com/stac-extensions/"
+            "label/main/examples/multidataset/catalog.json"
         )
+        self.url_searchable = "https://earth-search.aws.element84.com/v1"
+
+    @pytest.mark.vcr()
+    def test_get_open_data_params_schema(self):
+        stac_instance = Stac(self.url_nonsearchable)
+        schema = stac_instance.get_open_data_params_schema()
+        self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertIn("variable_names", schema.properties)
+        self.assertIn("time_range", schema.properties)
+        self.assertIn("bbox", schema.properties)
+        self.assertIn("collections", schema.properties)
+
+    @pytest.mark.vcr()
+    def test_get_item_collection(self):
+        stac_instance = Stac(self.url_nonsearchable)
+        items, data_id_items = stac_instance.get_item_collection()
+        data_id_items_expected = [
+            "zanzibar-collection/znz001",
+            "zanzibar-collection/znz029",
+            "spacenet-buildings-collection/AOI_2_Vegas_img2636",
+            "spacenet-buildings-collection/AOI_3_Paris_img1648",
+            "spacenet-buildings-collection/AOI_4_Shanghai_img3344"
+        ]
+        self.assertIsInstance(items, ItemCollection)
+        self.assertListEqual(data_id_items, data_id_items_expected)
+        self.assertEqual(len(items), len(data_id_items))
+
+    @pytest.mark.vcr()
+    def test_get_item_collection_open_params(self):
+        stac_instance = Stac(self.url_nonsearchable)
+        items, data_id_items = stac_instance.get_item_collection(
+            collections="zanzibar-collection",
+            bbox=[39.28, -5.74, 39.31, -5.72],
+            time_range=["2019-04-23", "2019-04-24"]
+        )
+        data_id_items_expected = [
+            "zanzibar-collection/znz001",
+        ]
+        self.assertIsInstance(items, ItemCollection)
+        self.assertListEqual(data_id_items, data_id_items_expected)
+        self.assertEqual(len(items), len(data_id_items))
+
+        items, data_id_items = stac_instance.get_item_collection(
+            collections="zanzibar-collection",
+            bbox=[39, -5., 41, -6],
+            time_range=["2019-04-28", "2019-04-30"]
+        )
+        self.assertIsInstance(items, ItemCollection)
+        self.assertEqual(len(items), 0)
+        self.assertEqual(len(items), len(data_id_items))
+
+    @pytest.mark.vcr()
+    def test_get_item_collection_searchable_catalog(self):
+        stac_instance = Stac(self.url_searchable)
+        items, data_id_items = stac_instance.get_item_collection(
+            variable_names="red",
+            collections=["sentinel-2-l2a"],
+            bbox=[9, 47, 10, 48],
+            time_range=["2020-03-01", "2020-03-05"]
+        )
+        data_id_items_expected = [
+            "sentinel-2-l2a/S2A_32TMT_20200305_0_L2A",
+            "sentinel-2-l2a/S2A_32TNT_20200305_0_L2A",
+            "sentinel-2-l2a/S2A_32UMU_20200305_0_L2A",
+            "sentinel-2-l2a/S2A_32UNU_20200305_0_L2A",
+            "sentinel-2-l2a/S2A_32TMT_20200302_1_L2A",
+            "sentinel-2-l2a/S2A_32TMT_20200302_0_L2A",
+            "sentinel-2-l2a/S2A_32TNT_20200302_1_L2A",
+            "sentinel-2-l2a/S2A_32TNT_20200302_0_L2A",
+            "sentinel-2-l2a/S2A_32UMU_20200302_1_L2A",
+            "sentinel-2-l2a/S2A_32UMU_20200302_0_L2A",
+            "sentinel-2-l2a/S2A_32UNU_20200302_1_L2A",
+            "sentinel-2-l2a/S2A_32UNU_20200302_0_L2A"
+        ]
+        self.assertIsInstance(items, ItemCollection)
+        self.assertListEqual(data_id_items, data_id_items_expected)
+        self.assertEqual(len(items), len(data_id_items))
+
+    @pytest.mark.vcr()
+    def test_assert_datetime(self):
+        class Item1():
+
+            def __init__(self) -> None:
+                self.properties = dict(
+                    datetime="2024-05-02T09:19:38.543000Z"
+                )
+
+        class Item2():
+
+            def __init__(self) -> None:
+                self.properties = dict(
+                    datetime="null",
+                    start_datetime="2023-12-02T09:19:38.543000Z",
+                    end_datetime="2024-05-02T09:19:38.543000Z"
+                )
+
+        item1_open_paramss = [
+            dict(time_range=["2024-04-30", "2024-05-03"]),
+            dict(time_range=["2024-04-26", "2024-05-02"]),
+            dict(time_range=["2024-04-26", "2024-05-01"]),
+        ]
+        item1_funs = [
+            self.assertTrue,
+            self.assertFalse,
+            self.assertFalse
+        ]
+
+        item2_open_paramss = [
+            dict(time_range=["2024-05-05", "2024-05-08"]),
+            dict(time_range=["2024-04-30", "2024-05-03"]),
+            dict(time_range=["2024-04-26", "2024-04-29"]),
+            dict(time_range=["2023-11-26", "2023-12-31"]),
+            dict(time_range=["2023-11-26", "2023-11-30"]),
+            dict(time_range=["2023-11-26", "2024-05-08"])
+        ]
+        item2_funs = [
+            self.assertFalse,
+            self.assertTrue,
+            self.assertTrue,
+            self.assertTrue,
+            self.assertFalse,
+            self.assertTrue
+        ]
+
+        stac_instance = Stac(self.url_nonsearchable)
+
+        item1 = Item1()
+        for (open_params, fun) in zip(item1_open_paramss, item1_funs):
+            fun(
+                stac_instance._assert_datetime(item1, **open_params)
+            )
+
+        item1 = Item2()
+        for (open_params, fun) in zip(item2_open_paramss, item2_funs):
+            fun(
+                stac_instance._assert_datetime(item1, **open_params)
+            )
+
+    @pytest.mark.vcr()
+    def test_assert_bbox_intersect(self):
+        class Item():
+
+            def __init__(self) -> None:
+                self.bbox = [0, 0, 1, 1]
+
+        item_open_paramss = [
+            dict(bbox=[0, 0, 1, 1]),
+            dict(bbox=[0.5, 0.5, 1.5, 1.5]),
+            dict(bbox=[-0.5, -0.5, 0.5, 0.5]),
+            dict(bbox=[1, 1, 2, 2]),
+            dict(bbox=[2, 2, 3, 3])
+        ]
+        item_funs = [
+            self.assertTrue,
+            self.assertTrue,
+            self.assertTrue,
+            self.assertTrue,
+            self.assertFalse
+        ]
+
+        stac_instance = Stac(self.url_nonsearchable)
+
+        item = Item()
+        for (open_params, fun) in zip(item_open_paramss, item_funs):
+            fun(
+                stac_instance._assert_bbox_intersect(item, **open_params)
+            )

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -20,86 +20,161 @@
 # SOFTWARE.
 
 import unittest
+import pytest
 
+from pystac import ItemCollection
 from xcube.util.jsonschema import JsonObjectSchema
-from xcube_stac.store import StacDataStore
+from xcube.core.store import DataStoreError
+from xcube.core.store.store import new_data_store
+from xcube_stac.constants import DATA_STORE_ID
 
 
 class StacDataStoreTest(unittest.TestCase):
 
-    def setUp(self) -> None:
-        self.store = StacDataStore(url="url")
+    def setUp(self):
+        self.url = (
+            "https://raw.githubusercontent.com/stac-extensions/"
+            "label/main/examples/multidataset/catalog.json"
+        )
+        self.data_id = "zanzibar-collection/znz001/raster"
 
+    @pytest.mark.vcr()
     def test_get_data_store_params_schema(self):
-        schema = self.store.get_data_store_params_schema()
+        store = new_data_store(DATA_STORE_ID, url=self.url)
+        schema = store.get_data_store_params_schema()
         self.assertIsInstance(schema, JsonObjectSchema)
         self.assertIn("url", schema.properties)
-        self.assertIn("collection_prefix", schema.properties)
         self.assertIn("data_id_delimiter", schema.properties)
         self.assertIn("url", schema.required)
 
+    @pytest.mark.vcr()
     def test_get_data_types(self):
-        self.assertEqual(("dataset",), self.store.get_data_types())
+        store = new_data_store(DATA_STORE_ID, url=self.url)
+        self.assertEqual(("dataset",), store.get_data_types())
 
+    @pytest.mark.vcr()
     def test_get_data_types_for_data(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         self.assertEqual(
             ("dataset",),
-            self.store.get_data_types_for_data("data_id1")
+            store.get_data_types_for_data(self.data_id)
         )
 
+    @pytest.mark.vcr()
     def test_get_data_ids(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         with self.assertRaises(NotImplementedError) as cm:
-            self.store.get_data_ids()
+            store.get_data_ids()
         self.assertEqual(
             "get_data_ids() operation is not supported yet",
             f"{cm.exception}",
         )
 
+    @pytest.mark.vcr()
     def test_has_data(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         with self.assertRaises(NotImplementedError) as cm:
-            self.store.has_data("data_id1")
+            store.has_data("data_id1")
         self.assertEqual(
             "has_data() operation is not supported yet",
             f"{cm.exception}",
         )
 
+    @pytest.mark.vcr()
+    def test_get_item_collection(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
+        items, data_id_items = store.get_item_collection(
+            collections="zanzibar-collection"
+        )
+        data_id_items_expected = [
+            "zanzibar-collection/znz001",
+            "zanzibar-collection/znz029"
+        ]
+        self.assertIsInstance(items, ItemCollection)
+        self.assertListEqual(data_id_items, data_id_items_expected)
+        self.assertEqual(len(items), len(data_id_items))
+
+    @pytest.mark.vcr()
     def test_describe_data(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         with self.assertRaises(NotImplementedError) as cm:
-            self.store.describe_data("data_id1")
+            store.describe_data(self.data_id)
         self.assertEqual(
             "describe_data() operation is not supported yet",
             f"{cm.exception}",
         )
 
+    @pytest.mark.vcr()
     def test_get_data_opener_ids(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         self.assertEqual(
             ("dataset:zarr:stac",),
-            self.store.get_data_opener_ids()
+            store.get_data_opener_ids()
         )
 
-    def test_get_open_data_params_schema(self):
-        schema = self.store.get_open_data_params_schema()
-        self.assertIsInstance(schema, JsonObjectSchema)
+    # TODO: add this test when has_data() works
+    # @pytest.mark.vcr()
+    # def test_get_data_opener_ids_optional_args(self):
+    #     store = new_data_store(DATA_STORE_ID, url=self.url)
+    #     with self.assertRaises(DataStoreError) as cm:
+    #         store.get_data_opener_ids(data_id="wrong_data_id")
+    #     self.assertEqual(
+    #         "Data resource 'wrong_data_id' is not available.",
+    #         f"{cm.exception}",
+    #     )
+    #     with self.assertRaises(DataStoreError) as cm:
+    #         store.get_data_opener_ids(data_type=str)
+    #     self.assertEqual(
+    #         "Data type must be 'dataset', but got <class 'str'>",
+    #         f"{cm.exception}",
+    #     )
 
+    @pytest.mark.vcr()
+    def test_get_open_data_params_schema(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
+        schema = store.get_open_data_params_schema()
+        self.assertIsInstance(schema, JsonObjectSchema)
+        self.assertIn("variable_names", schema.properties)
+        self.assertIn("time_range", schema.properties)
+        self.assertIn("bbox", schema.properties)
+        self.assertIn("collections", schema.properties)
+
+    @pytest.mark.vcr()
     def test_open_data(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         with self.assertRaises(NotImplementedError) as cm:
-            self.store.open_data("data_id1")
+            store.open_data(self.data_id)
         self.assertEqual(
             "open_data() operation is not supported yet",
             f"{cm.exception}",
         )
 
+    @pytest.mark.vcr()
+    def test_open_data_wrong_opener_id(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
+        with self.assertRaises(DataStoreError) as cm:
+            store.open_data(self.data_id, opener_id="wrong_opener_id")
+        self.assertEqual(
+            "Data opener identifier must be 'dataset:zarr:stac', "
+            "but got 'wrong_opener_id'",
+            f"{cm.exception}",
+        )
+
+    @pytest.mark.vcr()
     def test_search_data(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         with self.assertRaises(NotImplementedError) as cm:
-            self.store.search_data()
+            store.search_data()
         self.assertEqual(
             "search_data() operation is not supported yet",
             f"{cm.exception}",
         )
 
+    @pytest.mark.vcr()
     def test_get_search_params_schema(self):
+        store = new_data_store(DATA_STORE_ID, url=self.url)
         with self.assertRaises(NotImplementedError) as cm:
-            self.store.get_search_params_schema()
+            store.get_search_params_schema()
         self.assertEqual(
             "get_search_params_schema() operation is not supported yet",
             f"{cm.exception}",

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -20,12 +20,13 @@
 # SOFTWARE.
 
 import unittest
-import pytest
 
 from pystac import ItemCollection
-from xcube.util.jsonschema import JsonObjectSchema
+import pytest
 from xcube.core.store import DataStoreError
 from xcube.core.store.store import new_data_store
+from xcube.util.jsonschema import JsonObjectSchema
+
 from xcube_stac.constants import DATA_STORE_ID
 
 

--- a/xcube_stac/constants.py
+++ b/xcube_stac/constants.py
@@ -19,5 +19,59 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
+from xcube.util.jsonschema import (
+    JsonArraySchema,
+    JsonDateSchema,
+    JsonNumberSchema,
+    JsonStringSchema
+)
+
+
 DATA_STORE_ID = "stac"
 DATASET_OPENER_ID = f"dataset:zarr:{DATA_STORE_ID}"
+
+MIME_TYPES = [
+    "application/zarr",
+    "image/tiff"
+]
+
+STAC_SEARCH_ITEM_PARAMETERS = dict(
+    variable_names=JsonArraySchema(
+        items=(JsonStringSchema(min_length=0)),
+        unique_items=True,
+        title="Variable names in xarray.Dataset",
+        description=(
+            "Variable names are defined by assets"
+        )
+    ),
+    time_range=JsonArraySchema(
+        items=[
+            JsonDateSchema(nullable=True),
+            JsonDateSchema(nullable=True),
+        ],
+        title="Time Range",
+        description=(
+            "Time range given as pair of start and stop dates.  "
+            "Dates must be given using format 'YYYY-MM-DD'. "
+            "Start and stop are inclusive."
+        )
+    ),
+    bbox=JsonArraySchema(
+        items=(
+            JsonNumberSchema(),
+            JsonNumberSchema(),
+            JsonNumberSchema(),
+            JsonNumberSchema(),
+        ),
+        title="Bounding box [x1,y1, x2,y2] in geographical coordinates",
+    ),
+    collections=JsonArraySchema(
+        items=(JsonStringSchema(min_length=0)),
+        unique_items=True,
+        title="Collection IDs",
+        description=(
+            "Collection IDs to be included in the search request."
+        )
+    )
+)

--- a/xcube_stac/opener.py
+++ b/xcube_stac/opener.py
@@ -43,14 +43,7 @@ class StacDataOpener(DataOpener):
         self.stac = stac
 
     def get_open_data_params_schema(self, data_id: str = None) -> JsonObjectSchema:
-        # ToDo: to be adjusted
-        open_parms = {}
-        stac_schema = JsonObjectSchema(
-            properties=dict(**open_parms),
-            required=[],
-            additional_properties=False
-        )
-        return stac_schema
+        return self.stac.get_open_data_params_schema(data_id)
 
     def open_data(self, data_id: str, **open_params) -> xr.Dataset:
         """Open the data given by the data resource identifier *data_id*

--- a/xcube_stac/opener.py
+++ b/xcube_stac/opener.py
@@ -19,17 +19,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import logging
 import xarray as xr
-
-from xcube.util.jsonschema import JsonObjectSchema
 from xcube.core.store import (
     DataOpener,
     DatasetDescriptor
 )
-from .stac import Stac
+from xcube.util.jsonschema import JsonObjectSchema
 
-_LOG = logging.getLogger("xcube")
+from .stac import Stac
 
 
 class StacDataOpener(DataOpener):
@@ -40,7 +37,11 @@ class StacDataOpener(DataOpener):
     """
 
     def __init__(self, stac: Stac):
-        self.stac = stac
+        self._stac = stac
+
+    @property
+    def stac(self) -> Stac:
+        return self._stac
 
     def get_open_data_params_schema(self, data_id: str = None) -> JsonObjectSchema:
         return self.stac.get_open_data_params_schema(data_id)

--- a/xcube_stac/plugin.py
+++ b/xcube_stac/plugin.py
@@ -19,11 +19,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from xcube.constants import (
+    EXTENSION_POINT_DATA_OPENERS,
+    EXTENSION_POINT_DATA_STORES
+)
 from xcube.util import extension
-from xcube.constants import EXTENSION_POINT_DATA_OPENERS
-from xcube.constants import EXTENSION_POINT_DATA_STORES
-from xcube_stac.constants import DATASET_OPENER_ID
-from xcube_stac.constants import DATA_STORE_ID
+
+from .constants import (
+    DATASET_OPENER_ID,
+    DATA_STORE_ID
+)
 
 
 def init_plugin(ext_registry: extension.ExtensionRegistry):

--- a/xcube_stac/stac.py
+++ b/xcube_stac/stac.py
@@ -19,7 +19,21 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from typing import Tuple, Iterable, Iterator, Union, List
+
+from datetime import datetime, timezone
+from shapely.geometry import box
 import xarray as xr
+from itertools import chain
+
+import pystac
+
+import pystac_client
+from pystac import Catalog, Collection, ItemCollection, Item
+
+from xcube.util.jsonschema import JsonObjectSchema
+
+from xcube_stac.constants import STAC_SEARCH_ITEM_PARAMETERS
 
 
 class Stac:
@@ -27,8 +41,6 @@ class Stac:
 
     Attributes:
         url: URL to STAC catalog
-        collection_prefix: Path of collection used as
-            entry point. Defaults to None.
         data_id_delimiter: Delimiter used to separate
             collections, items and assets from each other.
             Defaults to "/".
@@ -37,14 +49,112 @@ class Stac:
     def __init__(
         self,
         url: str,
-        collection_prefix: str = None,
         data_id_delimiter: str = "/"
     ):
         self._url = url
-        self._collection_prefix = collection_prefix
         self._data_id_delimiter = data_id_delimiter
-        # ToDo: open Catalog and direct to entry point defined by *collection_prefix*
-        # ToDo: Add a data store "file", which will be used to open the hrefs
+
+        # if STAC catalog is not searchable, pystac_client
+        # falls back to pystac; to prevent warnings from pystac_client
+        # use catalog from pystac instead. For more discussion refer to
+        # https://github.com/xcube-dev/xcube-stac/issues/5
+        catalog = pystac_client.Client.open(url)
+        self._searchable = True
+        if not catalog.conforms_to("ITEM_SEARCH"):
+            catalog = pystac.Catalog.from_file(url)
+            self._searchable = False
+        self.catalog = catalog
+
+        # TODO: Add a data store "file" here when implementing
+        # open_data(), which will be used to open the hrefs
+
+    def get_open_data_params_schema(self, data_id: str = None) -> JsonObjectSchema:
+        """ Get the JSON schema for instantiating a new data store.
+
+        Returns:
+            The JSON schema for the data store's parameters.
+        """
+        stac_schema = JsonObjectSchema(
+            properties=dict(**STAC_SEARCH_ITEM_PARAMETERS),
+            required=[],
+            additional_properties=False
+        )
+        return stac_schema
+
+    def get_item_collection(
+        self, **open_params
+    ) -> Tuple[ItemCollection, List[str]]:
+        """ Collects all items within the given STAC catalog
+        using the supplied *open_params*.
+
+        Returns:
+            items: item collection containing all items identified by *open_params*
+            item_data_ids: data IDs corresponding to items
+        """
+        if self._searchable:
+            open_params_mod = open_params.copy()
+            if "variable_names" in open_params_mod:
+                del open_params_mod["variable_names"]
+            if "time_range" in open_params_mod:
+                open_params_mod["datetime"] = "/".join(open_params_mod["time_range"])
+                del open_params_mod["time_range"]
+            items = self.catalog.search(**open_params_mod).item_collection()
+        else:
+            items = self._get_items_nonsearchable_catalog(
+                self.catalog,
+                **open_params
+            )
+            items = ItemCollection(items)
+        item_data_ids = self.list_item_data_ids(items)
+        return items, item_data_ids
+
+    def get_item_data_id(self, item: Item) -> str:
+        """ Generates the data ID of an item, which follows the structure:
+
+            `collection_id_0/../collection_id_n/item_id`
+
+        Args:
+            item: item/feature
+
+        Returns:
+            data ID of an item
+        """
+        id_parts = []
+        pystac_object = item
+        while pystac_object.STAC_OBJECT_TYPE != "Catalog":
+            id_parts.append(pystac_object.id)
+            pystac_object = pystac_object.get_parent()
+        id_parts.reverse()
+        return self._data_id_delimiter.join(id_parts)
+
+    def get_item_data_ids(self, items: Iterable[Item]) -> Iterator[str]:
+        """ Generates the data ID of an item collection,
+        which follows the structure:
+
+            `collection_id_0/../collection_id_n/item_id`
+
+        Args:
+            items: item collection
+
+        Yields:
+            data ID of an item
+        """
+        for item in items:
+            yield self.get_item_data_id(item)
+
+    def list_item_data_ids(self, items: Iterable[Item]) -> List[str]:
+        """ Generates a list of data IDs for a given item collection,
+        which follows the structure:
+
+            `collection_id_0/../collection_id_n/item_id`
+
+        Args:
+            items: item collection
+
+        Returns:
+            list of data IDs for a given item collection
+        """
+        return list(self.get_item_data_ids(items))
 
     def open_data(self, data_id: str, **open_params) -> xr.Dataset:
         """Open the data given by the data resource identifier *data_id*
@@ -63,3 +173,107 @@ class Stac:
         """
         # ToDo: implement this method using data store "file", see __init__()
         raise NotImplementedError("open_data() operation is not supported yet")
+
+    def _get_items_nonsearchable_catalog(
+        self,
+        pystac_object: Union[Catalog, Collection],
+        recursive: bool = True,
+        **open_params
+    ) -> Iterator[Tuple[Item, str]]:
+        """ Get the items for a catalog of the catalog, which is not
+        conform with the 'ITEM_SEARCH' specifications.
+
+        Args:
+            pystac_object: either a `pystac.catalog:Catalog` or a
+                `pystac.collection:Collection` object
+            recursive: If True, data IDs of a multiple collection
+                and/or nested collection STAC catalog can be build. If False,
+                flat STAC catalog hierarchy is assumed consisting only of items.
+                Defaults to True.
+
+        Yields:
+            An iterator over the items matching the **open_params.
+        """
+
+        if (
+            pystac_object.extra_fields["type"] == "Collection" and
+            pystac_object.id not in open_params.get("collections", [pystac_object.id])
+        ):
+            pass
+        else:
+            if recursive:
+                if any(True for _ in pystac_object.get_children()):
+                    iterators = (self._get_items_nonsearchable_catalog(
+                        child,
+                        recursive=True,
+                        **open_params
+                    ) for child in pystac_object.get_children())
+                    yield from chain(*iterators)
+                else:
+                    iterator = self._get_items_nonsearchable_catalog(
+                        pystac_object,
+                        recursive=False,
+                        **open_params
+                    )
+                    yield from iterator
+            else:
+                for item in pystac_object.get_items():
+                    # test if item's bbox intersects with the desired bbox
+                    if "bbox" in open_params:
+                        if not self._assert_bbox_intersect(item, **open_params):
+                            continue
+                    # test if item fit to desired time range
+                    if "time_range" in open_params:
+                        if not self._assert_datetime(item, **open_params):
+                            continue
+                    # iterate through assets of item
+                    yield item
+
+    def _assert_datetime(self, item: Item, **open_params) -> bool:
+        """ Assert if the datetime or datetime range of an item fits to the
+        'time_range' given by *open_params*.
+
+        Args:
+            item: item/feature
+
+        Returns:
+            True, if the datetime of an item is within the 'time_range',
+            otherwise False. True, if there is any overlap between the
+            'time_range' and the datetime range of an item.
+
+        """
+        dt_start = datetime.fromisoformat(
+            open_params["time_range"][0]
+        ).replace(tzinfo=timezone.utc)
+        dt_end = datetime.fromisoformat(
+            open_params["time_range"][1]
+        ).replace(tzinfo=timezone.utc)
+        if item.properties["datetime"] == "null":
+            dt_start_data = datetime.fromisoformat(
+                item.properties["start_datetime"]
+            )
+            dt_end_data = datetime.fromisoformat(
+                item.properties["end_datetime"]
+            )
+            if dt_end < dt_start_data or dt_start > dt_end_data:
+                return False
+            else:
+                return True
+        else:
+            dt_data = datetime.fromisoformat(item.properties["datetime"])
+            if dt_end < dt_data or dt_start > dt_data:
+                return False
+            else:
+                return True
+
+    def _assert_bbox_intersect(self, item: Item, **open_params) -> bool:
+        """ Checks if two bounding boxes intersect.
+
+        Args:
+            item: item/feature
+
+        Returns:
+            True if the bounding box given by the item intersects with
+            the bounding box given by *open_params*. Otherwise False.
+        """
+        return box(*item.bbox).intersects(box(*open_params["bbox"]))

--- a/xcube_stac/stac.py
+++ b/xcube_stac/stac.py
@@ -19,10 +19,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from datetime import datetime, timezone
+from datetime import timezone
 from itertools import chain
 from typing import Tuple, Iterable, Iterator, Union, List
 
+import pandas as pd
 import pystac
 from pystac import Catalog, Collection, ItemCollection, Item
 import pystac_client
@@ -242,22 +243,22 @@ class Stac:
             the datetime range of an item; otherwise False.
 
         """
-        dt_start = datetime.fromisoformat(
+        dt_start = pd.Timestamp(
             open_params["time_range"][0]
-        ).replace(tzinfo=timezone.utc)
-        dt_end = datetime.fromisoformat(
+        ).to_pydatetime().replace(tzinfo=timezone.utc)
+        dt_end = pd.Timestamp(
             open_params["time_range"][1]
-        ).replace(tzinfo=timezone.utc)
+        ).to_pydatetime().replace(tzinfo=timezone.utc)
         if item.properties["datetime"] == "null":
-            dt_start_data = datetime.fromisoformat(
+            dt_start_data = pd.Timestamp(
                 item.properties["start_datetime"]
-            )
-            dt_end_data = datetime.fromisoformat(
+            ).to_pydatetime()
+            dt_end_data = pd.Timestamp(
                 item.properties["end_datetime"]
-            )
+            ).to_pydatetime()
             return dt_end >= dt_start_data and dt_start <= dt_end_data
         else:
-            dt_data = datetime.fromisoformat(item.properties["datetime"])
+            dt_data = pd.Timestamp(item.properties["datetime"]).to_pydatetime()
             return dt_start <= dt_data <= dt_end
 
     def _do_bboxes_intersect(self, item: Item, **open_params) -> bool:

--- a/xcube_stac/stac.py
+++ b/xcube_stac/stac.py
@@ -69,7 +69,7 @@ class Stac:
         # open_data(), which will be used to open the hrefs
 
     def get_open_data_params_schema(self, data_id: str = None) -> JsonObjectSchema:
-        """ Get the JSON schema for instantiating a new data store.
+        """Get the JSON schema for instantiating a new data store.
 
         Returns:
             The JSON schema for the data store's parameters.
@@ -84,7 +84,7 @@ class Stac:
     def get_item_collection(
         self, **open_params
     ) -> Tuple[ItemCollection, List[str]]:
-        """ Collects all items within the given STAC catalog
+        """Collects all items within the given STAC catalog
         using the supplied *open_params*.
 
         Returns:
@@ -109,7 +109,7 @@ class Stac:
         return items, item_data_ids
 
     def get_item_data_id(self, item: Item) -> str:
-        """ Generates the data ID of an item, which follows the structure:
+        """Generates the data ID of an item, which follows the structure:
 
             `collection_id_0/../collection_id_n/item_id`
 
@@ -128,7 +128,7 @@ class Stac:
         return self._data_id_delimiter.join(id_parts)
 
     def get_item_data_ids(self, items: Iterable[Item]) -> Iterator[str]:
-        """ Generates the data ID of an item collection,
+        """Generates the data ID of an item collection,
         which follows the structure:
 
             `collection_id_0/../collection_id_n/item_id`
@@ -143,7 +143,7 @@ class Stac:
             yield self.get_item_data_id(item)
 
     def list_item_data_ids(self, items: Iterable[Item]) -> List[str]:
-        """ Generates a list of data IDs for a given item collection,
+        """Generates a list of data IDs for a given item collection,
         which follows the structure:
 
             `collection_id_0/../collection_id_n/item_id`
@@ -180,7 +180,7 @@ class Stac:
         recursive: bool = True,
         **open_params
     ) -> Iterator[Tuple[Item, str]]:
-        """ Get the items for a catalog of the catalog, which is not
+        """Get the items for a catalog of the catalog, which is not
         conform with the 'ITEM_SEARCH' specifications.
 
         Args:
@@ -230,7 +230,7 @@ class Stac:
                     yield item
 
     def _assert_datetime(self, item: Item, **open_params) -> bool:
-        """ Assert if the datetime or datetime range of an item fits to the
+        """Assert if the datetime or datetime range of an item fits to the
         'time_range' given by *open_params*.
 
         Args:
@@ -267,7 +267,7 @@ class Stac:
                 return True
 
     def _assert_bbox_intersect(self, item: Item, **open_params) -> bool:
-        """ Checks if two bounding boxes intersect.
+        """Checks if two bounding boxes intersect.
 
         Args:
             item: item/feature

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -96,7 +96,7 @@ class StacDataStore(StacDataOpener, DataStore):
     def get_item_collection(
         self, **open_params
     ) -> Tuple[ItemCollection, List[str]]:
-        """ Collects all items within the given STAC catalog
+        """Collects all items within the given STAC catalog
         using the supplied *open_params*.
 
         Returns:

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -19,11 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Any, Tuple, Iterator, Dict, Container, Union
+from typing import Any, Tuple, Iterator, Dict, Container, Union, List
 
 import logging
 import xarray as xr
 
+from pystac import ItemCollection
 from xcube.util.jsonschema import (
     JsonObjectSchema,
     JsonStringSchema
@@ -71,10 +72,6 @@ class StacDataStore(StacDataOpener, DataStore):
         stac_params = dict(
             url=JsonStringSchema(
                 title="URL to STAC catalog"
-            ),
-            collection_prefix=JsonStringSchema(
-                title="Collection prefix",
-                description="Path of collection used as entry point",
             ),
             data_id_delimiter=JsonStringSchema(
                 title="Data ID delimiter",
@@ -151,12 +148,7 @@ class StacDataStore(StacDataOpener, DataStore):
         self._assert_valid_data_type(data_type)
         if data_id is not None and not self.has_data(data_id, data_type=data_type):
             raise DataStoreError(
-                f"Data resource {data_id!r}" f" is not available."
-            )
-        if data_type is not None and not DATASET_TYPE.is_super_type_of(data_type):
-            raise DataStoreError(
-                f"Data resource {data_id!r}" f" is not "
-                f"available as type {data_type!r}."
+                f"Data resource {data_id!r} is not available."
             )
         return (DATASET_OPENER_ID,)
 
@@ -249,10 +241,10 @@ class StacDataStore(StacDataOpener, DataStore):
         by the store.
 
         Args:
-            data_type: Data type that is to be checked.
+            data_type (DataTypeLike): Data type that is to be checked.
 
         Returns:
-            True if *data_type* is supported by the store, otherwise False
+            bool: True if *data_type* is supported by the store, otherwise False
         """
         return data_type is None or DATASET_TYPE.is_super_type_of(data_type)
 
@@ -262,7 +254,7 @@ class StacDataStore(StacDataOpener, DataStore):
         by the store.
 
         Args:
-            data_type: Data type that is to be checked.
+            data_type (DataTypeLike): Data type that is to be checked.
 
         Raises:
             DataStoreError: Error, if *data_type* is not
@@ -280,7 +272,7 @@ class StacDataStore(StacDataOpener, DataStore):
         *opener_id* is supported by the store.
 
         Args:
-            opener_id: Data opener identifier
+            opener_id (_type_): Data opener identifier
 
         Raises:
             DataStoreError: Error, if *opener_id* is not
@@ -288,7 +280,6 @@ class StacDataStore(StacDataOpener, DataStore):
         """
         if opener_id is not None and opener_id != DATASET_OPENER_ID:
             raise DataStoreError(
-                f"Data opener identifier must be"
-                f' "{DATASET_OPENER_ID}",'
-                f' but got "{opener_id}"'
+                f"Data opener identifier must be "
+                f'{DATASET_OPENER_ID!r}, but got {opener_id!r}'
             )

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -48,8 +48,6 @@ class StacDataStore(StacDataOpener, DataStore):
 
     Attributes:
         url: URL to STAC catalog
-        collection_prefix: Path of collection used as
-            entry point. Defaults to None.
         data_id_delimiter: Delimiter used to separate
             collections, items and assets from each other.
             Defaults to "/".
@@ -58,12 +56,10 @@ class StacDataStore(StacDataOpener, DataStore):
     def __init__(
         self,
         url: str,
-        collection_prefix: str = None,
         data_id_delimiter: str = "/"
     ):
         super().__init__(stac=Stac(
             url,
-            collection_prefix=collection_prefix,
             data_id_delimiter=data_id_delimiter
         ))
 
@@ -96,6 +92,18 @@ class StacDataStore(StacDataOpener, DataStore):
 
     def get_data_types_for_data(self, data_id: str) -> Tuple[str, ...]:
         return self.get_data_types()
+
+    def get_item_collection(
+        self, **open_params
+    ) -> Tuple[ItemCollection, List[str]]:
+        """ Collects all items within the given STAC catalog
+        using the supplied *open_params*.
+
+        Returns:
+            A tuple of the item collection containing all items
+            identified by *open_params* and data IDs corresponding to items
+        """
+        return self.stac.get_item_collection(**open_params)
 
     def get_data_ids(
         self, data_type: DataTypeLike = None, include_attrs: Container[str] = None

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -19,16 +19,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from pystac import ItemCollection
 from typing import Any, Tuple, Iterator, Dict, Container, Union, List
 
-import logging
 import xarray as xr
-
-from pystac import ItemCollection
-from xcube.util.jsonschema import (
-    JsonObjectSchema,
-    JsonStringSchema
-)
 from xcube.core.store import (
     DATASET_TYPE,
     DataDescriptor,
@@ -36,11 +30,14 @@ from xcube.core.store import (
     DataStoreError,
     DataTypeLike
 )
+from xcube.util.jsonschema import (
+    JsonObjectSchema,
+    JsonStringSchema
+)
+
 from .constants import DATASET_OPENER_ID
 from .opener import StacDataOpener
 from .stac import Stac
-
-_LOG = logging.getLogger("xcube")
 
 
 class StacDataStore(StacDataOpener, DataStore):
@@ -249,7 +246,7 @@ class StacDataStore(StacDataOpener, DataStore):
         by the store.
 
         Args:
-            data_type (DataTypeLike): Data type that is to be checked.
+            data_type: Data type that is to be checked.
 
         Returns:
             bool: True if *data_type* is supported by the store, otherwise False
@@ -262,7 +259,7 @@ class StacDataStore(StacDataOpener, DataStore):
         by the store.
 
         Args:
-            data_type (DataTypeLike): Data type that is to be checked.
+            data_type: Data type that is to be checked.
 
         Raises:
             DataStoreError: Error, if *data_type* is not


### PR DESCRIPTION
Closes #4

This PR work on the item level. The item_id is given by `collection_id_0/../collection_id_n/item_id`.
In the next PR this will be extended to the asset level which will give the final `data_id = collection_id_0/../collection_id_n/item_id/asset_id`. 

More discussion on unittesting using vcrpy, searchable and non-searchable catalogs, and `open_params` is given in #4. 



