### PR TITLE
conda default branch removed

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: xcube-stac
 channels:
   - conda-forge
-  - defaults
 dependencies:
   # Required
   - python>=3.10


### PR DESCRIPTION
Conda default branch is removed from `environment.yaml`.