### PR TITLE
Timeseries cube generation for Sentinel-2 (single-tile mode)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
   These stores are analogous to `stac-cdse` and `stac-cdse-ardc`, but offer 
   improved **cube generation performance** by leveraging
   **cloud-optimized GeoTIFFs (COGs)**.
+* **Timeseries cube generation for Sentinel-2 (single-tile mode):**  
+  A new mode was added that generates a time series cube from a single Sentinel-2 tile.  
+  Instead of providing `bbox` and `crs`, you now supply a `point` (lon, lat) together  
+  with a `bbox_width` in meters (must be < 10,000). The system will cut out a region  
+  around the given point, restricted to a single tile and native crs, and stack 
+  it along the time dimension. This improves cube generation performance.  
  
 ## Changes in 1.0.0
 

--- a/examples/notebooks/sentinel_2_cdse.ipynb
+++ b/examples/notebooks/sentinel_2_cdse.ipynb
@@ -1623,7 +1623,7 @@
     "    data_id=\"sentinel-2-l1c\",\n",
     "    bbox=[9.7, 53.3, 10.3, 53.8],\n",
     "    time_range=[\"2020-07-15\", \"2020-08-01\"],\n",
-    "    spatial_res=10 / 111320, # meter in degree\n",
+    "    spatial_res=10 / 111320,  # meter in degree\n",
     "    crs=\"EPSG:4326\",\n",
     "    asset_names=[\"B02\", \"B03\", \"B04\"],\n",
     "    add_angles=True,\n",
@@ -2902,7 +2902,7 @@
     "    data_id=\"sentinel-2-l2a\",\n",
     "    bbox=[9.7, 53.3, 10.3, 53.8],\n",
     "    time_range=[\"2020-07-15\", \"2020-08-01\"],\n",
-    "    spatial_res=10 / 111320, # meter in degree\n",
+    "    spatial_res=10 / 111320,  # meter in degree\n",
     "    crs=\"EPSG:4326\",\n",
     "    asset_names=[\"B02\", \"B03\", \"B04\", \"SCL\"],\n",
     "    add_angles=True,\n",
@@ -5476,7 +5476,7 @@
     "ds = store.open_data(\n",
     "    data_id=\"sentinel-2-l2a\",\n",
     "    point=(10.3, 53.3),\n",
-    "    bbox_width=1000, \n",
+    "    bbox_width=1000,\n",
     "    time_range=[\"2020-07-15\", \"2020-08-01\"],\n",
     "    spatial_res=10,\n",
     "    asset_names=[\"B02\", \"B03\", \"B04\", \"SCL\"],\n",
@@ -5520,7 +5520,7 @@
    ],
    "source": [
     "%%time\n",
-    "ds.B04.isel(time=0).plot( vmin=0, vmax=0.2)"
+    "ds.B04.isel(time=0).plot(vmin=0, vmax=0.2)"
    ]
   },
   {

--- a/examples/notebooks/sentinel_2_cdse.ipynb
+++ b/examples/notebooks/sentinel_2_cdse.ipynb
@@ -25,8 +25,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.3 s, sys: 299 ms, total: 4.6 s\n",
-      "Wall time: 3.03 s\n"
+      "CPU times: user 4.33 s, sys: 251 ms, total: 4.58 s\n",
+      "Wall time: 2.66 s\n"
      ]
     }
    ],
@@ -48,7 +48,7 @@
     {
      "data": {
       "text/plain": [
-       "<xarray.core.options.set_options at 0x772a5253b230>"
+       "<xarray.core.options.set_options at 0x73655e70ef90>"
       ]
      },
      "execution_count": 2,
@@ -110,8 +110,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 74.2 ms, sys: 14.1 ms, total: 88.3 ms\n",
-      "Wall time: 87.7 ms\n"
+      "CPU times: user 71.7 ms, sys: 10 ms, total: 81.8 ms\n",
+      "Wall time: 81.2 ms\n"
      ]
     },
     {
@@ -138,7 +138,7 @@
        "type": "object"
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x772a51b758d0>"
+       "<xcube.util.jsonschema.JsonObjectSchema at 0x73655de059b0>"
       ]
      },
      "execution_count": 4,
@@ -161,8 +161,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.8 ms, sys: 2.79 ms, total: 9.6 ms\n",
-      "Wall time: 114 ms\n"
+      "CPU times: user 8.8 ms, sys: 1.06 ms, total: 9.86 ms\n",
+      "Wall time: 123 ms\n"
      ]
     }
    ],
@@ -189,8 +189,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 19 μs, sys: 2 μs, total: 21 μs\n",
-      "Wall time: 23.1 μs\n"
+      "CPU times: user 17 μs, sys: 1 μs, total: 18 μs\n",
+      "Wall time: 20.3 μs\n"
      ]
     },
     {
@@ -226,119 +226,282 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 37.7 ms, sys: 24 ms, total: 61.6 ms\n",
-      "Wall time: 61.2 ms\n"
+      "CPU times: user 49.2 ms, sys: 12 ms, total: 61.2 ms\n",
+      "Wall time: 60.8 ms\n"
      ]
     },
     {
      "data": {
       "application/json": {
-       "additionalProperties": false,
-       "properties": {
-        "add_angles": {
-         "default": false,
-         "description": "Viewing and solar angles will be extracted for all spectral bands defined in keyword `asset_name`.",
-         "title": "Add viewing and solar angles from Sentinel2 metadata.",
-         "type": "boolean"
-        },
-        "apply_scaling": {
-         "default": true,
-         "title": "Apply scaling, offset, and no-data values to data.",
-         "type": "boolean"
-        },
-        "asset_names": {
-         "items": {
-          "enum": [
-           "B01",
-           "B02",
-           "B03",
-           "B04",
-           "B05",
-           "B06",
-           "B07",
-           "B08",
-           "B8A",
-           "B09",
-           "B11",
-           "B12",
-           "AOT",
-           "SCL",
-           "WVP"
-          ],
-          "minLength": 1,
-          "type": "string"
-         },
-         "title": "Names of assets (spectral bands)",
-         "type": "array",
-         "uniqueItems": true
-        },
-        "bbox": {
-         "items": [
-          {
+       "oneOf": [
+        {
+         "additionalProperties": false,
+         "properties": {
+          "add_angles": {
+           "default": false,
+           "description": "Viewing and solar angles will be extracted for all spectral bands defined in keyword `asset_name`.",
+           "title": "Add viewing and solar angles from Sentinel2 metadata.",
+           "type": "boolean"
+          },
+          "apply_scaling": {
+           "default": true,
+           "title": "Apply scaling, offset, and no-data values to data.",
+           "type": "boolean"
+          },
+          "asset_names": {
+           "items": {
+            "enum": [
+             "B01",
+             "B02",
+             "B03",
+             "B04",
+             "B05",
+             "B06",
+             "B07",
+             "B08",
+             "B8A",
+             "B09",
+             "B11",
+             "B12",
+             "AOT",
+             "SCL",
+             "WVP"
+            ],
+            "minLength": 1,
+            "type": "string"
+           },
+           "title": "Names of assets (spectral bands)",
+           "type": "array",
+           "uniqueItems": true
+          },
+          "bbox": {
+           "items": [
+            {
+             "type": "number"
+            },
+            {
+             "type": "number"
+            },
+            {
+             "type": "number"
+            },
+            {
+             "type": "number"
+            }
+           ],
+           "title": "Bounding box [x1,y1,x2,y2] in coordinates of the given CRS.",
+           "type": "array"
+          },
+          "crs": {
+           "default": "EPSG:4326",
+           "title": "Coordinate reference system",
+           "type": "string"
+          },
+          "query": {
+           "additionalProperties": true,
+           "description": "If STAC Catalog is conform with query extension, additional filtering based on the properties of Item objects is supported. For more information see https://github.com/stac-api-extensions/query",
+           "properties": {},
+           "title": "Additional query options used during item search of STAC API.",
+           "type": "object"
+          },
+          "spatial_res": {
+           "exclusiveMinimum": 0,
+           "title": "Spatial Resolution",
            "type": "number"
           },
-          {
-           "type": "number"
+          "tile_size": {
+           "default": 1024,
+           "description": "Either a tuple asigning width and height (x, y), or single int for quadratic chunk size.",
+           "oneOf": [
+            {
+             "minimum": 256,
+             "type": "number"
+            },
+            {
+             "items": [
+              {
+               "minimum": 256,
+               "type": "number"
+              },
+              {
+               "minimum": 256,
+               "type": "number"
+              }
+             ],
+             "type": "array"
+            }
+           ],
+           "title": "Spatial chunk size"
           },
-          {
-           "type": "number"
-          },
-          {
-           "type": "number"
+          "time_range": {
+           "description": "Time range given as pair of start and stop dates. Dates must be given using format 'YYYY-MM-DD'. Start and stop are inclusive.",
+           "items": [
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            },
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            }
+           ],
+           "title": "Time Range",
+           "type": "array"
           }
+         },
+         "required": [
+          "time_range",
+          "bbox",
+          "spatial_res",
+          "crs"
          ],
-         "title": "Bounding box [x1,y1,x2,y2] in geographical coordinates.",
-         "type": "array"
-        },
-        "crs": {
-         "default": "EPSG:4326",
-         "title": "Coordinate reference system",
-         "type": "string"
-        },
-        "query": {
-         "additionalProperties": true,
-         "description": "If STAC Catalog is conform with query extension, additional filtering based on the properties of Item objects is supported. For more information see https://github.com/stac-api-extensions/query",
-         "properties": {},
-         "title": "Additional query options used during item search of STAC API.",
+         "title": "Open parameters to open via a user-defined bounding box.",
          "type": "object"
         },
-        "spatial_res": {
-         "exclusiveMinimum": 0,
-         "title": "Spatial Resolution",
-         "type": "number"
-        },
-        "time_range": {
-         "description": "Time range given as pair of start and stop dates. Dates must be given using format 'YYYY-MM-DD'. Start and stop are inclusive.",
-         "items": [
-          {
-           "format": "date",
-           "type": [
-            "string",
-            "null"
-           ]
+        {
+         "additionalProperties": false,
+         "properties": {
+          "add_angles": {
+           "default": false,
+           "description": "Viewing and solar angles will be extracted for all spectral bands defined in keyword `asset_name`.",
+           "title": "Add viewing and solar angles from Sentinel2 metadata.",
+           "type": "boolean"
           },
-          {
-           "format": "date",
-           "type": [
-            "string",
-            "null"
-           ]
+          "apply_scaling": {
+           "default": true,
+           "title": "Apply scaling, offset, and no-data values to data.",
+           "type": "boolean"
+          },
+          "asset_names": {
+           "items": {
+            "enum": [
+             "B01",
+             "B02",
+             "B03",
+             "B04",
+             "B05",
+             "B06",
+             "B07",
+             "B08",
+             "B8A",
+             "B09",
+             "B11",
+             "B12",
+             "AOT",
+             "SCL",
+             "WVP"
+            ],
+            "minLength": 1,
+            "type": "string"
+           },
+           "title": "Names of assets (spectral bands)",
+           "type": "array",
+           "uniqueItems": true
+          },
+          "bbox_width": {
+           "exclusiveMinimum": 0,
+           "maximum": 10000,
+           "title": "Full width of bounding box in meter, aligned around the coordinates given in `point`.",
+           "type": "number"
+          },
+          "point": {
+           "items": [
+            {
+             "maximum": 180,
+             "minimum": -180,
+             "type": "number"
+            },
+            {
+             "maximum": 90,
+             "minimum": -90,
+             "type": "number"
+            }
+           ],
+           "title": "Point given in (lon, lat) in geographical coordinates.",
+           "type": "array"
+          },
+          "query": {
+           "additionalProperties": true,
+           "description": "If STAC Catalog is conform with query extension, additional filtering based on the properties of Item objects is supported. For more information see https://github.com/stac-api-extensions/query",
+           "properties": {},
+           "title": "Additional query options used during item search of STAC API.",
+           "type": "object"
+          },
+          "spatial_res": {
+           "default": 10,
+           "enum": [
+            10,
+            20,
+            60
+           ],
+           "title": "Spatial Resolution",
+           "type": "number"
+          },
+          "tile_size": {
+           "default": 1024,
+           "description": "Either a tuple asigning width and height (x, y), or single int for quadratic chunk size.",
+           "oneOf": [
+            {
+             "minimum": 256,
+             "type": "number"
+            },
+            {
+             "items": [
+              {
+               "minimum": 256,
+               "type": "number"
+              },
+              {
+               "minimum": 256,
+               "type": "number"
+              }
+             ],
+             "type": "array"
+            }
+           ],
+           "title": "Spatial chunk size"
+          },
+          "time_range": {
+           "description": "Time range given as pair of start and stop dates. Dates must be given using format 'YYYY-MM-DD'. Start and stop are inclusive.",
+           "items": [
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            },
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            }
+           ],
+           "title": "Time Range",
+           "type": "array"
           }
+         },
+         "required": [
+          "time_range",
+          "point",
+          "spatial_res",
+          "bbox_width"
          ],
-         "title": "Time Range",
-         "type": "array"
+         "title": "Open parameters to generate a cube cutout around a given `point`.",
+         "type": "object"
         }
-       },
-       "required": [
-        "time_range",
-        "bbox",
-        "spatial_res",
-        "crs"
-       ],
-       "type": "object"
+       ]
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x772a51126c10>"
+       "<xcube.util.jsonschema.JsonComplexSchema at 0x73655d47c190>"
       ]
      },
      "execution_count": 7,
@@ -368,8 +531,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 9.84 s, sys: 239 ms, total: 10.1 s\n",
-      "Wall time: 17.2 s\n"
+      "CPU times: user 22.8 s, sys: 129 ms, total: 22.9 s\n",
+      "Wall time: 30.9 s\n"
      ]
     },
     {
@@ -831,21 +994,21 @@
        "  * angle          (angle) object 16B &#x27;zenith&#x27; &#x27;azimuth&#x27;\n",
        "  * band           (band) &lt;U3 36B &#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;\n",
        "Data variables:\n",
-       "    B02            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    B03            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    B04            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
+       "    B02            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    B03            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    B04            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
        "    solar_angle    (angle, time, angle_lat, angle_lon) float32 11kB dask.array&lt;chunksize=(2, 1, 13, 15), meta=np.ndarray&gt;\n",
        "    viewing_angle  (angle, band, time, angle_lat, angle_lon) float32 33kB dask.array&lt;chunksize=(2, 3, 1, 13, 15), meta=np.ndarray&gt;\n",
-       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-cb64e8c4-0714-491d-9ad2-ac218b25a3fa' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-cb64e8c4-0714-491d-9ad2-ac218b25a3fa' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lon</span>: 6681</li><li><span class='xr-has-index'>lat</span>: 5567</li><li><span class='xr-has-index'>angle_lon</span>: 15</li><li><span class='xr-has-index'>angle_lat</span>: 13</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-e7309de3-cddb-4997-869e-45bfdadc5ae9' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e7309de3-cddb-4997-869e-45bfdadc5ae9' class='xr-section-summary' >Coordinates: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-16T10:40:31.024000 ... 2...</div><input id='attrs-c8266631-a0f2-4516-aba6-1a3c5c72d416' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c8266631-a0f2-4516-aba6-1a3c5c72d416' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3fdad93f-1838-425a-8d90-f049c3f824e3' class='xr-var-data-in' type='checkbox'><label for='data-3fdad93f-1838-425a-8d90-f049c3f824e3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-16T10:40:31.024000000&#x27;, &#x27;2020-07-18T10:25:59.024000000&#x27;,\n",
+       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-1f0d630c-f97b-443d-aa08-bf7165d9f9b7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-1f0d630c-f97b-443d-aa08-bf7165d9f9b7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lon</span>: 6681</li><li><span class='xr-has-index'>lat</span>: 5567</li><li><span class='xr-has-index'>angle_lon</span>: 15</li><li><span class='xr-has-index'>angle_lat</span>: 13</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-b758ab35-4f16-4db0-a303-ffa111428997' class='xr-section-summary-in' type='checkbox'  checked><label for='section-b758ab35-4f16-4db0-a303-ffa111428997' class='xr-section-summary' >Coordinates: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-16T10:40:31.024000 ... 2...</div><input id='attrs-a518bc93-7749-4e84-adb9-12d2ebf8026e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a518bc93-7749-4e84-adb9-12d2ebf8026e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c5ea0a1a-3c05-4c21-a29f-82b156771859' class='xr-var-data-in' type='checkbox'><label for='data-c5ea0a1a-3c05-4c21-a29f-82b156771859' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-16T10:40:31.024000000&#x27;, &#x27;2020-07-18T10:25:59.024000000&#x27;,\n",
        "       &#x27;2020-07-21T10:36:29.024000000&#x27;, &#x27;2020-07-23T10:30:31.024000000&#x27;,\n",
        "       &#x27;2020-07-26T10:40:31.024000000&#x27;, &#x27;2020-07-28T10:25:59.024000000&#x27;,\n",
-       "       &#x27;2020-07-31T10:36:29.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-8fb6d124-e482-45d0-aeda-340681551032' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8fb6d124-e482-45d0-aeda-340681551032' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-21fbfadb-ba01-46de-a61b-5e61ea12a9ee' class='xr-var-data-in' type='checkbox'><label for='data-21fbfadb-ba01-46de-a61b-5e61ea12a9ee' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2296)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],CS[ellipsoidal,2],AXIS[&quot;geodetic latitude (Lat)&quot;,north,ORDER[1],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],AXIS[&quot;geodetic longitude (Lon)&quot;,east,ORDER[2],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984 ensemble</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.7 9.7 9.7 ... 10.3 10.3 10.3</div><input id='attrs-fc1f4ffc-894f-42ea-8355-9f0374cc42a3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fc1f4ffc-894f-42ea-8355-9f0374cc42a3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b2838dbe-1bf2-423f-bbbb-58f248456e6a' class='xr-var-data-in' type='checkbox'><label for='data-b2838dbe-1bf2-423f-bbbb-58f248456e6a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.70009 ,  9.70018 , ..., 10.299892, 10.299982, 10.300072],\n",
-       "      shape=(6681,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.8 53.8 53.8 ... 53.3 53.3 53.3</div><input id='attrs-3cf50313-e3c5-4abd-a9c9-01afd70ac68d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3cf50313-e3c5-4abd-a9c9-01afd70ac68d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8c5d9de3-8c69-4436-b131-7ce371cb6433' class='xr-var-data-in' type='checkbox'><label for='data-8c5d9de3-8c69-4436-b131-7ce371cb6433' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.8    , 53.79991, 53.79982, ..., 53.30018, 53.30009, 53.3    ],\n",
-       "      shape=(5567,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lon</span></div><div class='xr-var-dims'>(angle_lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.746 9.791 ... 10.29 10.34</div><input id='attrs-eaf5caf2-488d-461a-a280-ff9a6a960bb4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-eaf5caf2-488d-461a-a280-ff9a6a960bb4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8bcf5967-f4b9-46ad-ae82-96983b2674e8' class='xr-var-data-in' type='checkbox'><label for='data-8bcf5967-f4b9-46ad-ae82-96983b2674e8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.745608,  9.791217,  9.836825,  9.882434,  9.928042,\n",
+       "       &#x27;2020-07-31T10:36:29.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-b80d470b-220c-414d-9d7a-fe4810cb8c88' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b80d470b-220c-414d-9d7a-fe4810cb8c88' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-18d331ea-e53c-48e0-93f2-22d559bf72ee' class='xr-var-data-in' type='checkbox'><label for='data-18d331ea-e53c-48e0-93f2-22d559bf72ee' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2296)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],CS[ellipsoidal,2],AXIS[&quot;geodetic latitude (Lat)&quot;,north,ORDER[1],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],AXIS[&quot;geodetic longitude (Lon)&quot;,east,ORDER[2],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984 ensemble</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.7 9.7 9.7 ... 10.3 10.3 10.3</div><input id='attrs-244d35b0-a7de-4193-9c58-df70b737e04a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-244d35b0-a7de-4193-9c58-df70b737e04a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb8cc529-01c9-4f2c-8ac9-9e04ed5b3e9e' class='xr-var-data-in' type='checkbox'><label for='data-eb8cc529-01c9-4f2c-8ac9-9e04ed5b3e9e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.70009 ,  9.70018 , ..., 10.299892, 10.299982, 10.300072],\n",
+       "      shape=(6681,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.8 53.8 53.8 ... 53.3 53.3 53.3</div><input id='attrs-525902fb-a144-43b8-9e03-5a2ad6b4d6a8' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-525902fb-a144-43b8-9e03-5a2ad6b4d6a8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-54ba9261-0fcb-4b69-a36d-7e6b60a8a93f' class='xr-var-data-in' type='checkbox'><label for='data-54ba9261-0fcb-4b69-a36d-7e6b60a8a93f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.8    , 53.79991, 53.79982, ..., 53.30018, 53.30009, 53.3    ],\n",
+       "      shape=(5567,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lon</span></div><div class='xr-var-dims'>(angle_lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.746 9.791 ... 10.29 10.34</div><input id='attrs-da464b64-b3ac-4ced-a5ba-8b5ff8d8afd9' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-da464b64-b3ac-4ced-a5ba-8b5ff8d8afd9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7f058b45-663f-470d-b9a3-6cbb00507954' class='xr-var-data-in' type='checkbox'><label for='data-7f058b45-663f-470d-b9a3-6cbb00507954' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.745608,  9.791217,  9.836825,  9.882434,  9.928042,\n",
        "        9.973651, 10.019259, 10.064868, 10.110476, 10.156085, 10.201693,\n",
-       "       10.247302, 10.29291 , 10.338518])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lat</span></div><div class='xr-var-dims'>(angle_lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.84 53.79 53.75 ... 53.34 53.3</div><input id='attrs-9651cc77-dc42-4f08-8449-6fe7fc346ab2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9651cc77-dc42-4f08-8449-6fe7fc346ab2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d8bf2aa2-c3e4-4f35-a7d5-ec8068ab4c33' class='xr-var-data-in' type='checkbox'><label for='data-d8bf2aa2-c3e4-4f35-a7d5-ec8068ab4c33' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.838987, 53.794071, 53.749156, 53.70424 , 53.659324, 53.614409,\n",
+       "       10.247302, 10.29291 , 10.338518])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lat</span></div><div class='xr-var-dims'>(angle_lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.84 53.79 53.75 ... 53.34 53.3</div><input id='attrs-fcec9c19-5a01-43df-8338-a4ef4687b31a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fcec9c19-5a01-43df-8338-a4ef4687b31a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-db768cd6-1acf-4efe-9cfa-028e797cde71' class='xr-var-data-in' type='checkbox'><label for='data-db768cd6-1acf-4efe-9cfa-028e797cde71' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.838987, 53.794071, 53.749156, 53.70424 , 53.659324, 53.614409,\n",
        "       53.569493, 53.524578, 53.479662, 53.434747, 53.389831, 53.344916,\n",
-       "       53.3     ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-3b3b6218-d554-4622-8fc5-5fffa461cbca' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3b3b6218-d554-4622-8fc5-5fffa461cbca' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6dda17a2-7b86-4248-ba34-1ebb0ef00b52' class='xr-var-data-in' type='checkbox'><label for='data-6dda17a2-7b86-4248-ba34-1ebb0ef00b52' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-e94d6d0b-143f-4594-8463-ab65e03c45cf' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e94d6d0b-143f-4594-8463-ab65e03c45cf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b5cd5887-6a7d-46c1-b23e-9d8084e4f5fc' class='xr-var-data-in' type='checkbox'><label for='data-b5cd5887-6a7d-46c1-b23e-9d8084e4f5fc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-35d39d52-5bc8-4fe7-9faf-f4b3f0444338' class='xr-section-summary-in' type='checkbox'  checked><label for='section-35d39d52-5bc8-4fe7-9faf-f4b3f0444338' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-05662d18-a389-466a-8fb3-64941464dda5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-05662d18-a389-466a-8fb3-64941464dda5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cc678374-edcb-4d30-9a9e-c2cec9131360' class='xr-var-data-in' type='checkbox'><label for='data-cc678374-edcb-4d30-9a9e-c2cec9131360' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "       53.3     ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-1eeb4242-a873-4869-8ad2-f1d105e11662' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1eeb4242-a873-4869-8ad2-f1d105e11662' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-637a4c3b-572d-41df-9e62-2529835df01f' class='xr-var-data-in' type='checkbox'><label for='data-637a4c3b-572d-41df-9e62-2529835df01f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-64c58c05-3371-4841-9971-c264fea7c4db' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-64c58c05-3371-4841-9971-c264fea7c4db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7c6091c2-104b-4826-ab87-b3f4e880fcca' class='xr-var-data-in' type='checkbox'><label for='data-7c6091c2-104b-4826-ab87-b3f4e880fcca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-60620034-229c-4c08-b48f-bb8104f49b54' class='xr-section-summary-in' type='checkbox'  checked><label for='section-60620034-229c-4c08-b48f-bb8104f49b54' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-65f55c24-43dd-4ac1-8e81-8ee3e9a329e3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-65f55c24-43dd-4ac1-8e81-8ee3e9a329e3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-78740c6d-8b13-4610-bf27-774197953cbe' class='xr-var-data-in' type='checkbox'><label for='data-78740c6d-8b13-4610-bf27-774197953cbe' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -861,17 +1024,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -885,8 +1048,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -914,8 +1080,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -924,14 +1093,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -945,7 +1120,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-230de771-1907-425d-b594-b82082838495' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-230de771-1907-425d-b594-b82082838495' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4f7b6849-78ee-4093-bc24-9ee8746c25fc' class='xr-var-data-in' type='checkbox'><label for='data-4f7b6849-78ee-4093-bc24-9ee8746c25fc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-a0ee4d4b-5802-48bb-ac93-4301cc7dc8aa' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a0ee4d4b-5802-48bb-ac93-4301cc7dc8aa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3a140ba3-7581-4bac-949b-e325c8cf3ad3' class='xr-var-data-in' type='checkbox'><label for='data-3a140ba3-7581-4bac-949b-e325c8cf3ad3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -961,17 +1136,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -985,8 +1160,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1014,8 +1192,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -1024,14 +1205,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -1045,7 +1232,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-14653d46-7f98-42ab-8b7e-0b61feb811ab' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-14653d46-7f98-42ab-8b7e-0b61feb811ab' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-94c52aab-8d1f-4d74-9385-0923a978b893' class='xr-var-data-in' type='checkbox'><label for='data-94c52aab-8d1f-4d74-9385-0923a978b893' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-7b2a733c-f2d3-46d9-a5e4-163af17e0c0d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7b2a733c-f2d3-46d9-a5e4-163af17e0c0d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d6ada3f4-42ac-4c69-9a47-8e744f6a0665' class='xr-var-data-in' type='checkbox'><label for='data-d6ada3f4-42ac-4c69-9a47-8e744f6a0665' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1061,17 +1248,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -1085,8 +1272,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -1114,8 +1304,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -1124,14 +1317,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -1145,7 +1344,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-763777b0-858f-4ad2-a399-db38991c77c6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-763777b0-858f-4ad2-a399-db38991c77c6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-704cf3af-d211-413f-aedd-fde673c5fb84' class='xr-var-data-in' type='checkbox'><label for='data-704cf3af-d211-413f-aedd-fde673c5fb84' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-1dd16ba3-a7fa-4e70-839a-8595dc86191c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1dd16ba3-a7fa-4e70-839a-8595dc86191c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1fef5aec-9e9f-42cf-9a59-cc77b7332002' class='xr-var-data-in' type='checkbox'><label for='data-1fef5aec-9e9f-42cf-9a59-cc77b7332002' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1251,7 +1450,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-e1b68dde-6320-42e5-8139-089e711c7d10' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e1b68dde-6320-42e5-8139-089e711c7d10' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-66f6d097-b09d-4e3b-be81-d62975ac8304' class='xr-var-data-in' type='checkbox'><label for='data-66f6d097-b09d-4e3b-be81-d62975ac8304' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-6e26463c-6014-4708-b9dc-edefb7d815e1' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6e26463c-6014-4708-b9dc-edefb7d815e1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9066178b-4b12-4374-9efe-c9e450b3f397' class='xr-var-data-in' type='checkbox'><label for='data-9066178b-4b12-4374-9efe-c9e450b3f397' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1357,39 +1556,39 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-622e095d-0054-4769-af48-2a39fc025354' class='xr-section-summary-in' type='checkbox'  ><label for='section-622e095d-0054-4769-af48-2a39fc025354' class='xr-section-summary' >Indexes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-6807a6ee-6cbf-43da-ad72-d3f575516abf' class='xr-index-data-in' type='checkbox'/><label for='index-6807a6ee-6cbf-43da-ad72-d3f575516abf' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-16 10:40:31.024000&#x27;, &#x27;2020-07-18 10:25:59.024000&#x27;,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-4f58db6b-226b-4f47-bc6e-03f92306cb06' class='xr-section-summary-in' type='checkbox'  ><label for='section-4f58db6b-226b-4f47-bc6e-03f92306cb06' class='xr-section-summary' >Indexes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-03579e13-ee16-473c-8b29-b1e8f6404dfe' class='xr-index-data-in' type='checkbox'/><label for='index-03579e13-ee16-473c-8b29-b1e8f6404dfe' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-16 10:40:31.024000&#x27;, &#x27;2020-07-18 10:25:59.024000&#x27;,\n",
        "               &#x27;2020-07-21 10:36:29.024000&#x27;, &#x27;2020-07-23 10:30:31.024000&#x27;,\n",
        "               &#x27;2020-07-26 10:40:31.024000&#x27;, &#x27;2020-07-28 10:25:59.024000&#x27;,\n",
        "               &#x27;2020-07-31 10:36:29.024000&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-387ded9b-44cf-4568-96f9-d3abaada7809' class='xr-index-data-in' type='checkbox'/><label for='index-387ded9b-44cf-4568-96f9-d3abaada7809' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.700089831117499,  9.700179662234998,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-0f654385-3690-4994-af01-a3690b123630' class='xr-index-data-in' type='checkbox'/><label for='index-0f654385-3690-4994-af01-a3690b123630' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.700089831117499,  9.700179662234998,\n",
        "        9.700269493352497,  9.700359324469996,  9.700449155587496,\n",
        "        9.700538986704993,  9.700628817822492,  9.700718648939992,\n",
        "        9.700808480057491,\n",
        "       ...\n",
-       "       10.299263384836507, 10.299353215954007, 10.299443047071506,\n",
-       "       10.299532878189005, 10.299622709306503, 10.299712540424002,\n",
-       "       10.299802371541501,    10.299892202659,   10.2999820337765,\n",
-       "       10.300071864893999],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;lon&#x27;, length=6681))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-1d8030f9-c9f3-42e4-a5c2-9359b9c33ff9' class='xr-index-data-in' type='checkbox'/><label for='index-1d8030f9-c9f3-42e4-a5c2-9359b9c33ff9' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([53.800000000000004, 53.799910168882505, 53.799820337765006,\n",
+       "       10.299263384836502, 10.299353215954001,   10.2994430470715,\n",
+       "          10.299532878189, 10.299622709306497, 10.299712540423997,\n",
+       "       10.299802371541496, 10.299892202658995, 10.299982033776494,\n",
+       "       10.300071864893994],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;lon&#x27;, length=6681))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-c7ef4531-1a5f-4bbd-b37d-055569e4f7e7' class='xr-index-data-in' type='checkbox'/><label for='index-c7ef4531-1a5f-4bbd-b37d-055569e4f7e7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([53.800000000000004, 53.799910168882505, 53.799820337765006,\n",
        "       53.799730506647506,  53.79964067553001,  53.79955084441251,\n",
        "        53.79946101329501,  53.79937118217751,  53.79928135106001,\n",
        "        53.79919151994251,\n",
        "       ...\n",
-       "        53.30080848005749,  53.30071864893999,  53.30062881782249,\n",
-       "        53.30053898670499,  53.30044915558749, 53.300359324469994,\n",
-       "       53.300269493352495, 53.300179662234996, 53.300089831117496,\n",
-       "                     53.3],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;lat&#x27;, length=5567))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-a0d876a4-4272-428d-867f-6249f88a5b0f' class='xr-index-data-in' type='checkbox'/><label for='index-a0d876a4-4272-428d-867f-6249f88a5b0f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.745608458685476,  9.791216917370955,\n",
+       "       53.300808480057476,  53.30071864893998,  53.30062881782248,\n",
+       "        53.30053898670498,  53.30044915558748,  53.30035932446998,\n",
+       "        53.30026949335248,  53.30017966223498,  53.30008983111748,\n",
+       "        53.29999999999998],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;lat&#x27;, length=5567))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-ebe73db0-3a2f-4ab4-8b9c-b89d1e705a97' class='xr-index-data-in' type='checkbox'/><label for='index-ebe73db0-3a2f-4ab4-8b9c-b89d1e705a97' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.745608458685476,  9.791216917370955,\n",
        "        9.836825376056431,   9.88243383474191,  9.928042293427387,\n",
        "        9.973650752112865, 10.019259210798342, 10.064867669483819,\n",
        "       10.110476128169298, 10.156084586854774, 10.201693045540253,\n",
        "        10.24730150422573, 10.292909962911208, 10.338518421596685],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lon&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-e4114dca-384f-49bd-a048-2f27d333ec00' class='xr-index-data-in' type='checkbox'/><label for='index-e4114dca-384f-49bd-a048-2f27d333ec00' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 53.83898670499461,  53.79407114624506,  53.74915558749551,\n",
-       "        53.70424002874596, 53.659324469996406, 53.614408911246855,\n",
-       "       53.569493352497304,  53.52457779374775,   53.4796622349982,\n",
-       "        53.43474667624865,   53.3898311174991,  53.34491555874955,\n",
-       "                     53.3],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lat&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-110c083b-7392-4d42-b974-f4f5d02e13d8' class='xr-index-data-in' type='checkbox'/><label for='index-110c083b-7392-4d42-b974-f4f5d02e13d8' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-33a05218-4e61-4b3a-ab66-de4d4285ab01' class='xr-index-data-in' type='checkbox'/><label for='index-33a05218-4e61-4b3a-ab66-de4d4285ab01' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a919ef46-cc7e-431e-971b-202785c4af63' class='xr-section-summary-in' type='checkbox'  ><label for='section-a919ef46-cc7e-431e-971b-202785c4af63' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-16T10:40:31.024000&#x27;: [&#x27;S2A_MSIL1C_20200716T104031_N0500_R008_T32UNE_20230410T061831&#x27;, &#x27;S2A_MSIL1C_20200716T104031_N0500_R008_T32UNE_20230325T085448&#x27;], &#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL1C_20200718T102559_N0500_R108_T32UNE_20230424T134010&#x27;], &#x27;2020-07-21T10:36:29.024000&#x27;: [&#x27;S2B_MSIL1C_20200721T103629_N0500_R008_T32UNE_20230613T173612&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL1C_20200723T103031_N0500_R108_T32UNE_20230504T051622&#x27;], &#x27;2020-07-26T10:40:31.024000&#x27;: [&#x27;S2A_MSIL1C_20200726T104031_N0500_R008_T32UNE_20230505T225242&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL1C_20200728T102559_N0500_R108_T32UNE_20230504T070434&#x27;], &#x27;2020-07-31T10:36:29.024000&#x27;: [&#x27;S2B_MSIL1C_20200731T103629_N0500_R008_T32UNE_20230523T095853&#x27;]}</dd><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lon&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-931670d4-89e6-4739-a9e6-9835ed5049e2' class='xr-index-data-in' type='checkbox'/><label for='index-931670d4-89e6-4739-a9e6-9835ed5049e2' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([53.838986704994596, 53.794071146245045, 53.749155587495494,\n",
+       "        53.70424002874594,  53.65932446999639,  53.61440891124684,\n",
+       "        53.56949335249729,  53.52457779374774,  53.47966223499819,\n",
+       "       53.434746676248636, 53.389831117499085, 53.344915558749534,\n",
+       "        53.29999999999998],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lat&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-16725717-b39e-451a-8ecf-2655b0ebc5b9' class='xr-index-data-in' type='checkbox'/><label for='index-16725717-b39e-451a-8ecf-2655b0ebc5b9' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-2373a459-f7a5-48f1-8a28-97e8c67451e5' class='xr-index-data-in' type='checkbox'/><label for='index-2373a459-f7a5-48f1-8a28-97e8c67451e5' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-dfd6e319-41e1-41b7-b809-1e3cf5ac62ed' class='xr-section-summary-in' type='checkbox'  ><label for='section-dfd6e319-41e1-41b7-b809-1e3cf5ac62ed' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-16T10:40:31.024000&#x27;: [&#x27;S2A_MSIL1C_20200716T104031_N0500_R008_T32UNE_20230410T061831&#x27;, &#x27;S2A_MSIL1C_20200716T104031_N0500_R008_T32UNE_20230325T085448&#x27;], &#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL1C_20200718T102559_N0500_R108_T32UNE_20230424T134010&#x27;], &#x27;2020-07-21T10:36:29.024000&#x27;: [&#x27;S2B_MSIL1C_20200721T103629_N0500_R008_T32UNE_20230613T173612&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL1C_20200723T103031_N0500_R108_T32UNE_20230504T051622&#x27;], &#x27;2020-07-26T10:40:31.024000&#x27;: [&#x27;S2A_MSIL1C_20200726T104031_N0500_R008_T32UNE_20230505T225242&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL1C_20200728T102559_N0500_R108_T32UNE_20230504T070434&#x27;], &#x27;2020-07-31T10:36:29.024000&#x27;: [&#x27;S2B_MSIL1C_20200731T103629_N0500_R008_T32UNE_20230523T095853&#x27;]}</dd><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 3GB\n",
@@ -1405,9 +1604,9 @@
        "  * angle          (angle) object 16B 'zenith' 'azimuth'\n",
        "  * band           (band) <U3 36B 'B02' 'B03' 'B04'\n",
        "Data variables:\n",
-       "    B02            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    B03            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    B04            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
+       "    B02            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    B03            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    B04            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
        "    solar_angle    (angle, time, angle_lat, angle_lon) float32 11kB dask.array<chunksize=(2, 1, 13, 15), meta=np.ndarray>\n",
        "    viewing_angle  (angle, band, time, angle_lat, angle_lon) float32 33kB dask.array<chunksize=(2, 3, 1, 13, 15), meta=np.ndarray>\n",
        "Attributes: (3)"
@@ -1448,14 +1647,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 12.8 s, sys: 3.3 s, total: 16.1 s\n",
-      "Wall time: 26.1 s\n"
+      "CPU times: user 9.68 s, sys: 562 ms, total: 10.2 s\n",
+      "Wall time: 14.2 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x772a4b8ed090>"
+       "<matplotlib.collections.QuadMesh at 0x736556edc550>"
       ]
      },
      "execution_count": 9,
@@ -1497,8 +1696,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 18.1 s, sys: 339 ms, total: 18.4 s\n",
-      "Wall time: 27.6 s\n"
+      "CPU times: user 28.9 s, sys: 144 ms, total: 29.1 s\n",
+      "Wall time: 36.5 s\n"
      ]
     },
     {
@@ -1960,22 +2159,22 @@
        "  * angle          (angle) object 16B &#x27;zenith&#x27; &#x27;azimuth&#x27;\n",
        "  * band           (band) &lt;U3 36B &#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;\n",
        "Data variables:\n",
-       "    B02            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    B03            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    B04            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    SCL            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
+       "    B02            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    B03            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    B04            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    SCL            (time, lat, lon) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
        "    solar_angle    (angle, time, angle_lat, angle_lon) float32 11kB dask.array&lt;chunksize=(2, 1, 13, 15), meta=np.ndarray&gt;\n",
        "    viewing_angle  (angle, band, time, angle_lat, angle_lon) float32 33kB dask.array&lt;chunksize=(2, 3, 1, 13, 15), meta=np.ndarray&gt;\n",
-       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-d5423ff4-1174-4ce1-a7f9-be2dd2d31f37' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-d5423ff4-1174-4ce1-a7f9-be2dd2d31f37' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lon</span>: 6681</li><li><span class='xr-has-index'>lat</span>: 5567</li><li><span class='xr-has-index'>angle_lon</span>: 15</li><li><span class='xr-has-index'>angle_lat</span>: 13</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-f4a07431-ce11-4ca0-86c2-6c99e5261006' class='xr-section-summary-in' type='checkbox'  checked><label for='section-f4a07431-ce11-4ca0-86c2-6c99e5261006' class='xr-section-summary' >Coordinates: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-16T10:40:31.024000 ... 2...</div><input id='attrs-14a7bdd2-3a2e-4fc2-974d-27516ffb994f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-14a7bdd2-3a2e-4fc2-974d-27516ffb994f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-76825185-b38b-41e2-894c-cb25cc0fb31b' class='xr-var-data-in' type='checkbox'><label for='data-76825185-b38b-41e2-894c-cb25cc0fb31b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-16T10:40:31.024000000&#x27;, &#x27;2020-07-18T10:25:59.024000000&#x27;,\n",
+       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-aa9ff84d-cda1-4156-b38c-0821e5572966' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-aa9ff84d-cda1-4156-b38c-0821e5572966' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 7</li><li><span class='xr-has-index'>lon</span>: 6681</li><li><span class='xr-has-index'>lat</span>: 5567</li><li><span class='xr-has-index'>angle_lon</span>: 15</li><li><span class='xr-has-index'>angle_lat</span>: 13</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-173fcb02-7201-4476-baab-95a5a27fda46' class='xr-section-summary-in' type='checkbox'  checked><label for='section-173fcb02-7201-4476-baab-95a5a27fda46' class='xr-section-summary' >Coordinates: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-16T10:40:31.024000 ... 2...</div><input id='attrs-36c66c06-094a-4b6e-8061-fb1b8f08dbc6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-36c66c06-094a-4b6e-8061-fb1b8f08dbc6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e9e42d68-409e-4650-b710-e6ba625ba34a' class='xr-var-data-in' type='checkbox'><label for='data-e9e42d68-409e-4650-b710-e6ba625ba34a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-16T10:40:31.024000000&#x27;, &#x27;2020-07-18T10:25:59.024000000&#x27;,\n",
        "       &#x27;2020-07-21T10:36:29.024000000&#x27;, &#x27;2020-07-23T10:30:31.024000000&#x27;,\n",
        "       &#x27;2020-07-26T10:40:31.024000000&#x27;, &#x27;2020-07-28T10:25:59.024000000&#x27;,\n",
-       "       &#x27;2020-07-31T10:36:29.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-ec5a3843-5427-49aa-8ddc-dbcb5296eb02' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-ec5a3843-5427-49aa-8ddc-dbcb5296eb02' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-458f3e42-e4ef-485c-b63d-8d25c0a7d41c' class='xr-var-data-in' type='checkbox'><label for='data-458f3e42-e4ef-485c-b63d-8d25c0a7d41c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2296)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],CS[ellipsoidal,2],AXIS[&quot;geodetic latitude (Lat)&quot;,north,ORDER[1],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],AXIS[&quot;geodetic longitude (Lon)&quot;,east,ORDER[2],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984 ensemble</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.7 9.7 9.7 ... 10.3 10.3 10.3</div><input id='attrs-fb39c447-876f-46c9-ba14-2760dff48b97' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fb39c447-876f-46c9-ba14-2760dff48b97' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d891e315-6fc1-48d9-bccc-12c1a1429893' class='xr-var-data-in' type='checkbox'><label for='data-d891e315-6fc1-48d9-bccc-12c1a1429893' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.70009 ,  9.70018 , ..., 10.299892, 10.299982, 10.300072],\n",
-       "      shape=(6681,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.8 53.8 53.8 ... 53.3 53.3 53.3</div><input id='attrs-fa869428-7b4e-40db-8246-ed5ef48004df' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-fa869428-7b4e-40db-8246-ed5ef48004df' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e5f026d-23a7-464e-bef6-efb144adf931' class='xr-var-data-in' type='checkbox'><label for='data-0e5f026d-23a7-464e-bef6-efb144adf931' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.8    , 53.79991, 53.79982, ..., 53.30018, 53.30009, 53.3    ],\n",
-       "      shape=(5567,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lon</span></div><div class='xr-var-dims'>(angle_lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.746 9.791 ... 10.29 10.34</div><input id='attrs-73733084-cdb0-4782-9755-d89f11fd44d3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-73733084-cdb0-4782-9755-d89f11fd44d3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2d92fb2b-2b6f-491c-a210-58afef5cdeb8' class='xr-var-data-in' type='checkbox'><label for='data-2d92fb2b-2b6f-491c-a210-58afef5cdeb8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.745608,  9.791217,  9.836825,  9.882434,  9.928042,\n",
+       "       &#x27;2020-07-31T10:36:29.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-d8b92d44-db1a-4fd6-94b7-8654fbb6c41b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-d8b92d44-db1a-4fd6-94b7-8654fbb6c41b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f8f289aa-2b0f-44a3-95ed-710093c9a5de' class='xr-var-data-in' type='checkbox'><label for='data-f8f289aa-2b0f-44a3-95ed-710093c9a5de' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>GEOGCRS[&quot;WGS 84&quot;,ENSEMBLE[&quot;World Geodetic System 1984 ensemble&quot;,MEMBER[&quot;World Geodetic System 1984 (Transit)&quot;],MEMBER[&quot;World Geodetic System 1984 (G730)&quot;],MEMBER[&quot;World Geodetic System 1984 (G873)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1150)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1674)&quot;],MEMBER[&quot;World Geodetic System 1984 (G1762)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2139)&quot;],MEMBER[&quot;World Geodetic System 1984 (G2296)&quot;],ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]],ENSEMBLEACCURACY[2.0]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],CS[ellipsoidal,2],AXIS[&quot;geodetic latitude (Lat)&quot;,north,ORDER[1],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],AXIS[&quot;geodetic longitude (Lon)&quot;,east,ORDER[2],ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],USAGE[SCOPE[&quot;Horizontal component of 3D system.&quot;],AREA[&quot;World.&quot;],BBOX[-90,-180,90,180]],ID[&quot;EPSG&quot;,4326]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984 ensemble</dd><dt><span>grid_mapping_name :</span></dt><dd>latitude_longitude</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.7 9.7 9.7 ... 10.3 10.3 10.3</div><input id='attrs-c79ef09c-2fb3-4ac4-bc66-f07025778b8a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c79ef09c-2fb3-4ac4-bc66-f07025778b8a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dcb1c430-39cb-4de3-875d-738077527828' class='xr-var-data-in' type='checkbox'><label for='data-dcb1c430-39cb-4de3-875d-738077527828' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.70009 ,  9.70018 , ..., 10.299892, 10.299982, 10.300072],\n",
+       "      shape=(6681,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.8 53.8 53.8 ... 53.3 53.3 53.3</div><input id='attrs-b4d5694f-6b05-494d-a06f-05a2ebce629e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b4d5694f-6b05-494d-a06f-05a2ebce629e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c6bc77af-2e39-45eb-9a00-afb8a34204b3' class='xr-var-data-in' type='checkbox'><label for='data-c6bc77af-2e39-45eb-9a00-afb8a34204b3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.8    , 53.79991, 53.79982, ..., 53.30018, 53.30009, 53.3    ],\n",
+       "      shape=(5567,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lon</span></div><div class='xr-var-dims'>(angle_lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>9.7 9.746 9.791 ... 10.29 10.34</div><input id='attrs-a2d0cc77-050d-45e3-8375-5b56b262798c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a2d0cc77-050d-45e3-8375-5b56b262798c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-644efe48-3940-4484-a69a-5285425ccd2c' class='xr-var-data-in' type='checkbox'><label for='data-644efe48-3940-4484-a69a-5285425ccd2c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([ 9.7     ,  9.745608,  9.791217,  9.836825,  9.882434,  9.928042,\n",
        "        9.973651, 10.019259, 10.064868, 10.110476, 10.156085, 10.201693,\n",
-       "       10.247302, 10.29291 , 10.338518])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lat</span></div><div class='xr-var-dims'>(angle_lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.84 53.79 53.75 ... 53.34 53.3</div><input id='attrs-9b2234c9-0839-454d-aaf0-38a4687153bc' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9b2234c9-0839-454d-aaf0-38a4687153bc' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9f7889a5-f839-41d5-be71-17e323138c7d' class='xr-var-data-in' type='checkbox'><label for='data-9f7889a5-f839-41d5-be71-17e323138c7d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.838987, 53.794071, 53.749156, 53.70424 , 53.659324, 53.614409,\n",
+       "       10.247302, 10.29291 , 10.338518])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_lat</span></div><div class='xr-var-dims'>(angle_lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>53.84 53.79 53.75 ... 53.34 53.3</div><input id='attrs-3ee43ab8-5b14-489f-a68d-184319b04425' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3ee43ab8-5b14-489f-a68d-184319b04425' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ecbae660-44b7-434c-9956-51337f8551f6' class='xr-var-data-in' type='checkbox'><label for='data-ecbae660-44b7-434c-9956-51337f8551f6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([53.838987, 53.794071, 53.749156, 53.70424 , 53.659324, 53.614409,\n",
        "       53.569493, 53.524578, 53.479662, 53.434747, 53.389831, 53.344916,\n",
-       "       53.3     ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-f6b270c3-1eae-4790-868b-22f9fc31ffe3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-f6b270c3-1eae-4790-868b-22f9fc31ffe3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3925c860-ea69-4911-a76a-f058c2bf0235' class='xr-var-data-in' type='checkbox'><label for='data-3925c860-ea69-4911-a76a-f058c2bf0235' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-06361b37-18a5-4d2e-9214-8496b5b82252' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-06361b37-18a5-4d2e-9214-8496b5b82252' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1a630dc6-1777-41be-bf70-6b952eabe978' class='xr-var-data-in' type='checkbox'><label for='data-1a630dc6-1777-41be-bf70-6b952eabe978' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a475bc41-6b22-4154-8548-d0d1f2ed19a2' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a475bc41-6b22-4154-8548-d0d1f2ed19a2' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-7e10f298-4fa9-4476-9741-f2492f8d44fa' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7e10f298-4fa9-4476-9741-f2492f8d44fa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cef2b9aa-8c24-4125-9eee-98ccccf803bc' class='xr-var-data-in' type='checkbox'><label for='data-cef2b9aa-8c24-4125-9eee-98ccccf803bc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "       53.3     ])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-9d6f9a17-db7d-4b1f-9d80-4ea3810229c5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9d6f9a17-db7d-4b1f-9d80-4ea3810229c5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-94f352db-28a2-4db7-a89c-e9858ed13995' class='xr-var-data-in' type='checkbox'><label for='data-94f352db-28a2-4db7-a89c-e9858ed13995' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-ee486eb0-28ec-4b89-ba09-86f573bca805' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ee486eb0-28ec-4b89-ba09-86f573bca805' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c47343b1-8044-4037-afd0-f7a8702537fa' class='xr-var-data-in' type='checkbox'><label for='data-c47343b1-8044-4037-afd0-f7a8702537fa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-d956d8e6-4c55-4da7-a575-6a833eb930e6' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d956d8e6-4c55-4da7-a575-6a833eb930e6' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-5afc2b0b-6e3e-4764-bab0-0335e96537db' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5afc2b0b-6e3e-4764-bab0-0335e96537db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c149959d-ce6d-47d9-9b99-1fe7f355368a' class='xr-var-data-in' type='checkbox'><label for='data-c149959d-ce6d-47d9-9b99-1fe7f355368a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1991,17 +2190,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -2015,8 +2214,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -2044,8 +2246,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2054,14 +2259,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2075,7 +2286,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-96a7e14c-4dfb-472f-827d-10ea04820b2c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-96a7e14c-4dfb-472f-827d-10ea04820b2c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5ccf5f11-aa47-43f2-a81e-8717c16ccee5' class='xr-var-data-in' type='checkbox'><label for='data-5ccf5f11-aa47-43f2-a81e-8717c16ccee5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-716d2175-b71c-4620-ab1b-3a2a531fa0e3' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-716d2175-b71c-4620-ab1b-3a2a531fa0e3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c540b532-0ca0-48b2-a30e-ac9d955b318c' class='xr-var-data-in' type='checkbox'><label for='data-c540b532-0ca0-48b2-a30e-ac9d955b318c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2091,17 +2302,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -2115,8 +2326,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -2144,8 +2358,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2154,14 +2371,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2175,7 +2398,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-1b12ab85-c602-4fbb-b849-26a7cccde0d7' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1b12ab85-c602-4fbb-b849-26a7cccde0d7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-274e5645-ea59-48e7-85e6-5503013e4887' class='xr-var-data-in' type='checkbox'><label for='data-274e5645-ea59-48e7-85e6-5503013e4887' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-669b8dd2-a532-4147-9e2a-a8f675a40e2f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-669b8dd2-a532-4147-9e2a-a8f675a40e2f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5d396ba2-1682-4346-a317-114a2390c90b' class='xr-var-data-in' type='checkbox'><label for='data-5d396ba2-1682-4346-a317-114a2390c90b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2191,17 +2414,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -2215,8 +2438,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -2244,8 +2470,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2254,14 +2483,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2275,7 +2510,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-b6059db0-831d-4f53-9d81-9efec6b1daeb' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b6059db0-831d-4f53-9d81-9efec6b1daeb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e4eba56-29b2-4ea9-9531-9ddcd708b41d' class='xr-var-data-in' type='checkbox'><label for='data-0e4eba56-29b2-4ea9-9531-9ddcd708b41d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, lat, lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-924c2667-63f1-4ed0-a35e-53b5f9b195d6' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-924c2667-63f1-4ed0-a35e-53b5f9b195d6' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5eb8795b-34f4-4a9c-8fa7-843b6471e0e5' class='xr-var-data-in' type='checkbox'><label for='data-5eb8795b-34f4-4a9c-8fa7-843b6471e0e5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2291,17 +2526,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.97 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (7, 5567, 6681) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 84 chunks in 46 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 294 chunks in 76 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -2315,8 +2550,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"18\" x2=\"24\" y2=\"33\" />\n",
        "  <line x1=\"10\" y1=\"36\" x2=\"24\" y2=\"51\" />\n",
+       "  <line x1=\"10\" y1=\"55\" x2=\"24\" y2=\"70\" />\n",
        "  <line x1=\"10\" y1=\"73\" x2=\"24\" y2=\"88\" />\n",
+       "  <line x1=\"10\" y1=\"91\" x2=\"24\" y2=\"106\" />\n",
        "  <line x1=\"10\" y1=\"99\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -2344,8 +2582,11 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"0\" x2=\"43\" y2=\"14\" />\n",
        "  <line x1=\"46\" y1=\"0\" x2=\"61\" y2=\"14\" />\n",
+       "  <line x1=\"65\" y1=\"0\" x2=\"80\" y2=\"14\" />\n",
        "  <line x1=\"83\" y1=\"0\" x2=\"98\" y2=\"14\" />\n",
+       "  <line x1=\"101\" y1=\"0\" x2=\"116\" y2=\"14\" />\n",
        "  <line x1=\"120\" y1=\"0\" x2=\"135\" y2=\"14\" />\n",
        "  <line x1=\"130\" y1=\"0\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2354,14 +2595,20 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"144\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"33\" x2=\"144\" y2=\"33\" />\n",
        "  <line x1=\"24\" y1=\"51\" x2=\"144\" y2=\"51\" />\n",
+       "  <line x1=\"24\" y1=\"70\" x2=\"144\" y2=\"70\" />\n",
        "  <line x1=\"24\" y1=\"88\" x2=\"144\" y2=\"88\" />\n",
+       "  <line x1=\"24\" y1=\"106\" x2=\"144\" y2=\"106\" />\n",
        "  <line x1=\"24\" y1=\"114\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"114\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"43\" y1=\"14\" x2=\"43\" y2=\"114\" />\n",
        "  <line x1=\"61\" y1=\"14\" x2=\"61\" y2=\"114\" />\n",
+       "  <line x1=\"80\" y1=\"14\" x2=\"80\" y2=\"114\" />\n",
        "  <line x1=\"98\" y1=\"14\" x2=\"98\" y2=\"114\" />\n",
+       "  <line x1=\"116\" y1=\"14\" x2=\"116\" y2=\"114\" />\n",
        "  <line x1=\"135\" y1=\"14\" x2=\"135\" y2=\"114\" />\n",
        "  <line x1=\"144\" y1=\"14\" x2=\"144\" y2=\"114\" style=\"stroke-width:2\" />\n",
        "\n",
@@ -2375,7 +2622,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-0a4eaf19-e4dc-460a-b3ce-505994e9b4cf' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0a4eaf19-e4dc-460a-b3ce-505994e9b4cf' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-477b4ad7-1396-4e0a-b778-0c6e6c24f28f' class='xr-var-data-in' type='checkbox'><label for='data-477b4ad7-1396-4e0a-b778-0c6e6c24f28f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-723c4b2b-ab05-4684-87e6-db3bf3a34385' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-723c4b2b-ab05-4684-87e6-db3bf3a34385' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-50e0b914-5b1c-4baf-ad92-b44c97acaadb' class='xr-var-data-in' type='checkbox'><label for='data-50e0b914-5b1c-4baf-ad92-b44c97acaadb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2481,7 +2728,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-2dec35d7-ffa1-49a2-b1ff-5cc7a8ef6868' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-2dec35d7-ffa1-49a2-b1ff-5cc7a8ef6868' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bf001ec1-8a09-48f0-8222-ec8a1dd14133' class='xr-var-data-in' type='checkbox'><label for='data-bf001ec1-8a09-48f0-8222-ec8a1dd14133' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, time, angle_lat, angle_lon)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 1, 13, 15), meta=np.ndarray&gt;</div><input id='attrs-d7ce6e89-7937-4d6f-83da-ae8f7acaf58e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d7ce6e89-7937-4d6f-83da-ae8f7acaf58e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d6ca2b1f-b966-4608-8d12-544cf122e7a8' class='xr-var-data-in' type='checkbox'><label for='data-d6ca2b1f-b966-4608-8d12-544cf122e7a8' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -2587,39 +2834,39 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-d235321f-45bf-4d4c-87c7-a5f86d0a04d8' class='xr-section-summary-in' type='checkbox'  ><label for='section-d235321f-45bf-4d4c-87c7-a5f86d0a04d8' class='xr-section-summary' >Indexes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-713f7dd4-4723-4a8f-84ab-92bed3fb7254' class='xr-index-data-in' type='checkbox'/><label for='index-713f7dd4-4723-4a8f-84ab-92bed3fb7254' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-16 10:40:31.024000&#x27;, &#x27;2020-07-18 10:25:59.024000&#x27;,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-65aa0c48-f6d6-419a-9d57-e310962c1cac' class='xr-section-summary-in' type='checkbox'  ><label for='section-65aa0c48-f6d6-419a-9d57-e310962c1cac' class='xr-section-summary' >Indexes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-114de9cd-8849-440c-8e25-1df2fd786983' class='xr-index-data-in' type='checkbox'/><label for='index-114de9cd-8849-440c-8e25-1df2fd786983' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-16 10:40:31.024000&#x27;, &#x27;2020-07-18 10:25:59.024000&#x27;,\n",
        "               &#x27;2020-07-21 10:36:29.024000&#x27;, &#x27;2020-07-23 10:30:31.024000&#x27;,\n",
        "               &#x27;2020-07-26 10:40:31.024000&#x27;, &#x27;2020-07-28 10:25:59.024000&#x27;,\n",
        "               &#x27;2020-07-31 10:36:29.024000&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-f58196ab-ef01-4054-89e0-cde326b23158' class='xr-index-data-in' type='checkbox'/><label for='index-f58196ab-ef01-4054-89e0-cde326b23158' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.700089831117499,  9.700179662234998,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-ab01129e-48c9-4d78-88c7-aec2071a7bdc' class='xr-index-data-in' type='checkbox'/><label for='index-ab01129e-48c9-4d78-88c7-aec2071a7bdc' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.700089831117499,  9.700179662234998,\n",
        "        9.700269493352497,  9.700359324469996,  9.700449155587496,\n",
        "        9.700538986704993,  9.700628817822492,  9.700718648939992,\n",
        "        9.700808480057491,\n",
        "       ...\n",
-       "       10.299263384836507, 10.299353215954007, 10.299443047071506,\n",
-       "       10.299532878189005, 10.299622709306503, 10.299712540424002,\n",
-       "       10.299802371541501,    10.299892202659,   10.2999820337765,\n",
-       "       10.300071864893999],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;lon&#x27;, length=6681))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-a16882ca-0146-49b5-bbcb-dfa18cfb5655' class='xr-index-data-in' type='checkbox'/><label for='index-a16882ca-0146-49b5-bbcb-dfa18cfb5655' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([53.800000000000004, 53.799910168882505, 53.799820337765006,\n",
+       "       10.299263384836502, 10.299353215954001,   10.2994430470715,\n",
+       "          10.299532878189, 10.299622709306497, 10.299712540423997,\n",
+       "       10.299802371541496, 10.299892202658995, 10.299982033776494,\n",
+       "       10.300071864893994],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;lon&#x27;, length=6681))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-20eb9d0b-aecd-42d1-8a4b-a8b44adf9895' class='xr-index-data-in' type='checkbox'/><label for='index-20eb9d0b-aecd-42d1-8a4b-a8b44adf9895' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([53.800000000000004, 53.799910168882505, 53.799820337765006,\n",
        "       53.799730506647506,  53.79964067553001,  53.79955084441251,\n",
        "        53.79946101329501,  53.79937118217751,  53.79928135106001,\n",
        "        53.79919151994251,\n",
        "       ...\n",
-       "        53.30080848005749,  53.30071864893999,  53.30062881782249,\n",
-       "        53.30053898670499,  53.30044915558749, 53.300359324469994,\n",
-       "       53.300269493352495, 53.300179662234996, 53.300089831117496,\n",
-       "                     53.3],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;lat&#x27;, length=5567))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-9428f2a6-0a2c-4b00-b3cd-71b894dae694' class='xr-index-data-in' type='checkbox'/><label for='index-9428f2a6-0a2c-4b00-b3cd-71b894dae694' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.745608458685476,  9.791216917370955,\n",
+       "       53.300808480057476,  53.30071864893998,  53.30062881782248,\n",
+       "        53.30053898670498,  53.30044915558748,  53.30035932446998,\n",
+       "        53.30026949335248,  53.30017966223498,  53.30008983111748,\n",
+       "        53.29999999999998],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;lat&#x27;, length=5567))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-fe5f8ded-91b7-4353-bb8b-3ddeccb3fdd1' class='xr-index-data-in' type='checkbox'/><label for='index-fe5f8ded-91b7-4353-bb8b-3ddeccb3fdd1' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([               9.7,  9.745608458685476,  9.791216917370955,\n",
        "        9.836825376056431,   9.88243383474191,  9.928042293427387,\n",
        "        9.973650752112865, 10.019259210798342, 10.064867669483819,\n",
        "       10.110476128169298, 10.156084586854774, 10.201693045540253,\n",
        "        10.24730150422573, 10.292909962911208, 10.338518421596685],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lon&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-cb5a4bcc-1798-419a-ab87-68cc5c281f35' class='xr-index-data-in' type='checkbox'/><label for='index-cb5a4bcc-1798-419a-ab87-68cc5c281f35' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ 53.83898670499461,  53.79407114624506,  53.74915558749551,\n",
-       "        53.70424002874596, 53.659324469996406, 53.614408911246855,\n",
-       "       53.569493352497304,  53.52457779374775,   53.4796622349982,\n",
-       "        53.43474667624865,   53.3898311174991,  53.34491555874955,\n",
-       "                     53.3],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lat&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-81087660-bab3-4931-a70d-888101accb50' class='xr-index-data-in' type='checkbox'/><label for='index-81087660-bab3-4931-a70d-888101accb50' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-63a83426-37d2-42d6-835e-a77f098a5525' class='xr-index-data-in' type='checkbox'/><label for='index-63a83426-37d2-42d6-835e-a77f098a5525' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a523db9e-fec8-47a1-b555-b94b8e4f68ef' class='xr-section-summary-in' type='checkbox'  ><label for='section-a523db9e-fec8-47a1-b555-b94b8e4f68ef' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-16T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230410T110332&#x27;, &#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230325T195238&#x27;], &#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200718T102559_N0500_R108_T32UNE_20230425T043013&#x27;], &#x27;2020-07-21T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200721T103629_N0500_R008_T32UNE_20230614T014152&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200723T103031_N0500_R108_T32UNE_20230504T135307&#x27;], &#x27;2020-07-26T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200726T104031_N0500_R008_T32UNE_20230506T073348&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200728T102559_N0500_R108_T32UNE_20230505T111819&#x27;], &#x27;2020-07-31T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200731T103629_N0500_R008_T32UNE_20230523T160015&#x27;]}</dd><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lon&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-751766f7-c07a-4f3c-8a4a-dd4775756462' class='xr-index-data-in' type='checkbox'/><label for='index-751766f7-c07a-4f3c-8a4a-dd4775756462' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([53.838986704994596, 53.794071146245045, 53.749155587495494,\n",
+       "        53.70424002874594,  53.65932446999639,  53.61440891124684,\n",
+       "        53.56949335249729,  53.52457779374774,  53.47966223499819,\n",
+       "       53.434746676248636, 53.389831117499085, 53.344915558749534,\n",
+       "        53.29999999999998],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_lat&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-1a4fc5eb-7bf7-4da0-84a5-7ece8bffa2e7' class='xr-index-data-in' type='checkbox'/><label for='index-1a4fc5eb-7bf7-4da0-84a5-7ece8bffa2e7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-ea13d1f3-5bf9-434f-bd67-cdc079544ce3' class='xr-index-data-in' type='checkbox'/><label for='index-ea13d1f3-5bf9-434f-bd67-cdc079544ce3' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1e032aa2-ceb3-4586-a0ad-21148d065a31' class='xr-section-summary-in' type='checkbox'  ><label for='section-1e032aa2-ceb3-4586-a0ad-21148d065a31' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-16T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230410T110332&#x27;, &#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230325T195238&#x27;], &#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200718T102559_N0500_R108_T32UNE_20230425T043013&#x27;], &#x27;2020-07-21T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200721T103629_N0500_R008_T32UNE_20230614T014152&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200723T103031_N0500_R108_T32UNE_20230504T135307&#x27;], &#x27;2020-07-26T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200726T104031_N0500_R008_T32UNE_20230506T073348&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200728T102559_N0500_R108_T32UNE_20230505T111819&#x27;], &#x27;2020-07-31T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200731T103629_N0500_R008_T32UNE_20230523T160015&#x27;]}</dd><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 4GB\n",
@@ -2635,10 +2882,10 @@
        "  * angle          (angle) object 16B 'zenith' 'azimuth'\n",
        "  * band           (band) <U3 36B 'B02' 'B03' 'B04'\n",
        "Data variables:\n",
-       "    B02            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    B03            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    B04            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    SCL            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
+       "    B02            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    B03            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    B04            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    SCL            (time, lat, lon) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
        "    solar_angle    (angle, time, angle_lat, angle_lon) float32 11kB dask.array<chunksize=(2, 1, 13, 15), meta=np.ndarray>\n",
        "    viewing_angle  (angle, band, time, angle_lat, angle_lon) float32 33kB dask.array<chunksize=(2, 3, 1, 13, 15), meta=np.ndarray>\n",
        "Attributes: (3)"
@@ -2679,14 +2926,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 20.2 s, sys: 4.33 s, total: 24.5 s\n",
-      "Wall time: 35.4 s\n"
+      "CPU times: user 11.5 s, sys: 421 ms, total: 11.9 s\n",
+      "Wall time: 15.7 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x772a52415bd0>"
+       "<matplotlib.collections.QuadMesh at 0x73654f6e9310>"
       ]
      },
      "execution_count": 11,
@@ -2728,8 +2975,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.01 ms, sys: 1 ms, total: 3.01 ms\n",
-      "Wall time: 1.51 ms\n"
+      "CPU times: user 1.1 ms, sys: 23 μs, total: 1.13 ms\n",
+      "Wall time: 576 μs\n"
      ]
     }
    ],
@@ -2749,8 +2996,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 7.51 s, sys: 458 ms, total: 7.97 s\n",
-      "Wall time: 20.4 s\n"
+      "CPU times: user 3.67 s, sys: 183 ms, total: 3.85 s\n",
+      "Wall time: 13 s\n"
      ]
     },
     {
@@ -3212,22 +3459,22 @@
        "  * angle          (angle) object 16B &#x27;zenith&#x27; &#x27;azimuth&#x27;\n",
        "  * band           (band) &lt;U3 36B &#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;\n",
        "Data variables:\n",
-       "    B02            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    B03            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    B04            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
-       "    SCL            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;\n",
+       "    B02            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    B03            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    B04            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
+       "    SCL            (time, y, x) float32 1GB dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;\n",
        "    solar_angle    (angle, time, angle_y, angle_x) float32 11kB dask.array&lt;chunksize=(2, 1, 13, 10), meta=np.ndarray&gt;\n",
        "    viewing_angle  (angle, band, time, angle_y, angle_x) float32 34kB dask.array&lt;chunksize=(2, 3, 1, 13, 10), meta=np.ndarray&gt;\n",
-       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-0e75d332-9e2e-4c9d-991b-bf917ddbe2a5' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-0e75d332-9e2e-4c9d-991b-bf917ddbe2a5' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 11</li><li><span class='xr-has-index'>y</span>: 5619</li><li><span class='xr-has-index'>x</span>: 4054</li><li><span class='xr-has-index'>angle_x</span>: 10</li><li><span class='xr-has-index'>angle_y</span>: 13</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-c8d0c42d-cd63-412d-bcfd-233a15f13d12' class='xr-section-summary-in' type='checkbox'  checked><label for='section-c8d0c42d-cd63-412d-bcfd-233a15f13d12' class='xr-section-summary' >Coordinates: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-15T10:15:59.024000 ... 2...</div><input id='attrs-8e7c4749-aed6-4540-88d9-bb8cbf163b8b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8e7c4749-aed6-4540-88d9-bb8cbf163b8b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7b9025b4-95ab-4533-bf63-b75b81a03ca0' class='xr-var-data-in' type='checkbox'><label for='data-7b9025b4-95ab-4533-bf63-b75b81a03ca0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-15T10:15:59.024000000&#x27;, &#x27;2020-07-16T10:40:31.024000000&#x27;,\n",
+       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-f9ba91db-2e52-47fd-8208-30054e2ecaa0' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-f9ba91db-2e52-47fd-8208-30054e2ecaa0' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 11</li><li><span class='xr-has-index'>y</span>: 5619</li><li><span class='xr-has-index'>x</span>: 4054</li><li><span class='xr-has-index'>angle_x</span>: 10</li><li><span class='xr-has-index'>angle_y</span>: 13</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-d6dac346-bf82-456c-8844-5d95a8b94212' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d6dac346-bf82-456c-8844-5d95a8b94212' class='xr-section-summary' >Coordinates: <span>(8)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-15T10:15:59.024000 ... 2...</div><input id='attrs-650361ef-6591-435c-8f03-975c0cccc07c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-650361ef-6591-435c-8f03-975c0cccc07c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1f83b561-1a7f-46dd-b0b9-98763fdea639' class='xr-var-data-in' type='checkbox'><label for='data-1f83b561-1a7f-46dd-b0b9-98763fdea639' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-15T10:15:59.024000000&#x27;, &#x27;2020-07-16T10:40:31.024000000&#x27;,\n",
        "       &#x27;2020-07-18T10:25:59.024000000&#x27;, &#x27;2020-07-20T10:20:31.024000000&#x27;,\n",
        "       &#x27;2020-07-21T10:36:29.024000000&#x27;, &#x27;2020-07-23T10:30:31.024000000&#x27;,\n",
        "       &#x27;2020-07-25T10:15:59.024000000&#x27;, &#x27;2020-07-26T10:40:31.024000000&#x27;,\n",
        "       &#x27;2020-07-28T10:25:59.024000000&#x27;, &#x27;2020-07-30T10:20:31.024000000&#x27;,\n",
-       "       &#x27;2020-07-31T10:36:29.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-a67fcce1-31ab-429f-ac3c-05f1a819fd6d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a67fcce1-31ab-429f-ac3c-05f1a819fd6d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-344f8fcd-b852-4055-9e91-5a0701a20051' class='xr-var-data-in' type='checkbox'><label for='data-344f8fcd-b852-4055-9e91-5a0701a20051' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.461e+05 5.461e+05 ... 5.866e+05</div><input id='attrs-6ec942be-c321-4933-b197-3c5f92f2fe24' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-6ec942be-c321-4933-b197-3c5f92f2fe24' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2104fb27-8cdd-42e7-ba10-f3b356c1b88f' class='xr-var-data-in' type='checkbox'><label for='data-2104fb27-8cdd-42e7-ba10-f3b356c1b88f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([546105., 546115., 546125., ..., 586615., 586625., 586635.],\n",
-       "      shape=(4054,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.962e+06 5.962e+06 ... 5.906e+06</div><input id='attrs-4de89240-d734-4ba4-87e0-a5d28f3de69b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4de89240-d734-4ba4-87e0-a5d28f3de69b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5b324839-b7db-42a7-b827-b6b831d3dfb1' class='xr-var-data-in' type='checkbox'><label for='data-5b324839-b7db-42a7-b827-b6b831d3dfb1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5962055., 5962045., 5962035., ..., 5905895., 5905885., 5905875.],\n",
-       "      shape=(5619,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_x</span></div><div class='xr-var-dims'>(angle_x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.461e+05 5.511e+05 ... 5.911e+05</div><input id='attrs-0dd1812b-6c4f-4d73-b57f-67157810bd30' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0dd1812b-6c4f-4d73-b57f-67157810bd30' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0e759224-8abf-4ea3-814e-0abc6b07ba47' class='xr-var-data-in' type='checkbox'><label for='data-0e759224-8abf-4ea3-814e-0abc6b07ba47' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([546105., 551105., 556105., 561105., 566105., 571105., 576105., 581105.,\n",
-       "       586105., 591105.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_y</span></div><div class='xr-var-dims'>(angle_y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.966e+06 5.961e+06 ... 5.906e+06</div><input id='attrs-66bbc27d-e8c3-4f44-bf61-39bba9c88c28' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-66bbc27d-e8c3-4f44-bf61-39bba9c88c28' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dd878448-9fc2-4a35-99c4-c96ab1a80ea4' class='xr-var-data-in' type='checkbox'><label for='data-dd878448-9fc2-4a35-99c4-c96ab1a80ea4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5965875., 5960875., 5955875., 5950875., 5945875., 5940875., 5935875.,\n",
-       "       5930875., 5925875., 5920875., 5915875., 5910875., 5905875.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-8e6a3b39-89fd-4d97-a919-feee39ea3532' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8e6a3b39-89fd-4d97-a919-feee39ea3532' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f0c0b647-e472-4201-861a-491d0c15ffea' class='xr-var-data-in' type='checkbox'><label for='data-f0c0b647-e472-4201-861a-491d0c15ffea' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-0aa66b5a-7317-46fb-979b-8d373b670a7a' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0aa66b5a-7317-46fb-979b-8d373b670a7a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-56b4743f-8a7a-4d8c-9733-fddffdb49a0b' class='xr-var-data-in' type='checkbox'><label for='data-56b4743f-8a7a-4d8c-9733-fddffdb49a0b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-14e36ec6-cefc-429f-872e-f19045edd1cb' class='xr-section-summary-in' type='checkbox'  checked><label for='section-14e36ec6-cefc-429f-872e-f19045edd1cb' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-9ba698c8-34e0-49bf-9318-8677935d7ea5' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-9ba698c8-34e0-49bf-9318-8677935d7ea5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1096aaf0-968d-4c5b-a9ff-7794dd81d4d6' class='xr-var-data-in' type='checkbox'><label for='data-1096aaf0-968d-4c5b-a9ff-7794dd81d4d6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "       &#x27;2020-07-31T10:36:29.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-9a5b8f51-410e-4d83-a8c1-e30edfc58103' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9a5b8f51-410e-4d83-a8c1-e30edfc58103' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2c2dd671-e7fe-4d30-b7c7-e0c9c74b4352' class='xr-var-data-in' type='checkbox'><label for='data-2c2dd671-e7fe-4d30-b7c7-e0c9c74b4352' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.461e+05 5.461e+05 ... 5.866e+05</div><input id='attrs-c2e5d9e1-4a38-44c7-9c24-ddb87fa4fc7b' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c2e5d9e1-4a38-44c7-9c24-ddb87fa4fc7b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5a681696-bd47-4c15-b966-783c191cfe06' class='xr-var-data-in' type='checkbox'><label for='data-5a681696-bd47-4c15-b966-783c191cfe06' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([546105., 546115., 546125., ..., 586615., 586625., 586635.],\n",
+       "      shape=(4054,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.962e+06 5.962e+06 ... 5.906e+06</div><input id='attrs-8ec6290c-9d05-45a2-9748-c62059e4879e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8ec6290c-9d05-45a2-9748-c62059e4879e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a8a72089-e61c-4fc5-bb05-8b5783ecccf2' class='xr-var-data-in' type='checkbox'><label for='data-a8a72089-e61c-4fc5-bb05-8b5783ecccf2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5962055., 5962045., 5962035., ..., 5905895., 5905885., 5905875.],\n",
+       "      shape=(5619,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_x</span></div><div class='xr-var-dims'>(angle_x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.461e+05 5.511e+05 ... 5.911e+05</div><input id='attrs-b9e353e1-58f6-4b74-87a3-a666ab92be28' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b9e353e1-58f6-4b74-87a3-a666ab92be28' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b3ef9f6b-2c05-42d7-aa73-53977e60c29f' class='xr-var-data-in' type='checkbox'><label for='data-b3ef9f6b-2c05-42d7-aa73-53977e60c29f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([546105., 551105., 556105., 561105., 566105., 571105., 576105., 581105.,\n",
+       "       586105., 591105.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_y</span></div><div class='xr-var-dims'>(angle_y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.966e+06 5.961e+06 ... 5.906e+06</div><input id='attrs-67007856-c426-4659-bfd1-5cc4a22771e7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-67007856-c426-4659-bfd1-5cc4a22771e7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-35200a65-1bc4-42fe-bea8-088f6a28daa5' class='xr-var-data-in' type='checkbox'><label for='data-35200a65-1bc4-42fe-bea8-088f6a28daa5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5965875., 5960875., 5955875., 5950875., 5945875., 5940875., 5935875.,\n",
+       "       5930875., 5925875., 5920875., 5915875., 5910875., 5905875.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-d9622c23-42c4-45fe-9b20-4d1f1168fb9e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d9622c23-42c4-45fe-9b20-4d1f1168fb9e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3607cb60-f314-4015-aab4-50270224b514' class='xr-var-data-in' type='checkbox'><label for='data-3607cb60-f314-4015-aab4-50270224b514' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-b958365e-9877-4e98-95e8-5642971d2ac2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-b958365e-9877-4e98-95e8-5642971d2ac2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5bd7fe10-61b1-4d7e-8e71-8667bb77a4df' class='xr-var-data-in' type='checkbox'><label for='data-5bd7fe10-61b1-4d7e-8e71-8667bb77a4df' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-db17431b-ea33-4576-a194-fe466c05b233' class='xr-section-summary-in' type='checkbox'  checked><label for='section-db17431b-ea33-4576-a194-fe466c05b233' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-c7132fee-8063-48eb-99da-65c3dd0c3741' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-c7132fee-8063-48eb-99da-65c3dd0c3741' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a383314f-1629-4be1-afa9-ca8865161045' class='xr-var-data-in' type='checkbox'><label for='data-a383314f-1629-4be1-afa9-ca8865161045' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3243,17 +3490,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.93 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (11, 5619, 4054) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 66 chunks in 12 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 264 chunks in 12 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -3267,8 +3514,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"21\" x2=\"24\" y2=\"36\" />\n",
        "  <line x1=\"10\" y1=\"43\" x2=\"24\" y2=\"58\" />\n",
+       "  <line x1=\"10\" y1=\"65\" x2=\"24\" y2=\"80\" />\n",
        "  <line x1=\"10\" y1=\"87\" x2=\"24\" y2=\"102\" />\n",
+       "  <line x1=\"10\" y1=\"109\" x2=\"24\" y2=\"124\" />\n",
        "  <line x1=\"10\" y1=\"120\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -3304,7 +3554,9 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"31\" y1=\"0\" x2=\"46\" y2=\"14\" />\n",
        "  <line x1=\"53\" y1=\"0\" x2=\"68\" y2=\"14\" />\n",
+       "  <line x1=\"75\" y1=\"0\" x2=\"90\" y2=\"14\" />\n",
        "  <line x1=\"96\" y1=\"0\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3312,13 +3564,18 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"36\" x2=\"111\" y2=\"36\" />\n",
        "  <line x1=\"24\" y1=\"58\" x2=\"111\" y2=\"58\" />\n",
+       "  <line x1=\"24\" y1=\"80\" x2=\"111\" y2=\"80\" />\n",
        "  <line x1=\"24\" y1=\"102\" x2=\"111\" y2=\"102\" />\n",
+       "  <line x1=\"24\" y1=\"124\" x2=\"111\" y2=\"124\" />\n",
        "  <line x1=\"24\" y1=\"134\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"46\" y1=\"14\" x2=\"46\" y2=\"134\" />\n",
        "  <line x1=\"68\" y1=\"14\" x2=\"68\" y2=\"134\" />\n",
+       "  <line x1=\"90\" y1=\"14\" x2=\"90\" y2=\"134\" />\n",
        "  <line x1=\"111\" y1=\"14\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3331,7 +3588,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-e4d16953-b9e4-4f45-ac7d-26560b8954ed' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e4d16953-b9e4-4f45-ac7d-26560b8954ed' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dd34d2c0-71c6-4a83-905d-0e7d73ae68c7' class='xr-var-data-in' type='checkbox'><label for='data-dd34d2c0-71c6-4a83-905d-0e7d73ae68c7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-8393a93d-bbe3-44bd-8167-0d364cb883ee' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-8393a93d-bbe3-44bd-8167-0d364cb883ee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f999a822-c679-4d94-8616-83f5b4c8188c' class='xr-var-data-in' type='checkbox'><label for='data-f999a822-c679-4d94-8616-83f5b4c8188c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3347,17 +3604,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.93 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (11, 5619, 4054) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 66 chunks in 12 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 264 chunks in 12 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -3371,8 +3628,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"21\" x2=\"24\" y2=\"36\" />\n",
        "  <line x1=\"10\" y1=\"43\" x2=\"24\" y2=\"58\" />\n",
+       "  <line x1=\"10\" y1=\"65\" x2=\"24\" y2=\"80\" />\n",
        "  <line x1=\"10\" y1=\"87\" x2=\"24\" y2=\"102\" />\n",
+       "  <line x1=\"10\" y1=\"109\" x2=\"24\" y2=\"124\" />\n",
        "  <line x1=\"10\" y1=\"120\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -3408,7 +3668,9 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"31\" y1=\"0\" x2=\"46\" y2=\"14\" />\n",
        "  <line x1=\"53\" y1=\"0\" x2=\"68\" y2=\"14\" />\n",
+       "  <line x1=\"75\" y1=\"0\" x2=\"90\" y2=\"14\" />\n",
        "  <line x1=\"96\" y1=\"0\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3416,13 +3678,18 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"36\" x2=\"111\" y2=\"36\" />\n",
        "  <line x1=\"24\" y1=\"58\" x2=\"111\" y2=\"58\" />\n",
+       "  <line x1=\"24\" y1=\"80\" x2=\"111\" y2=\"80\" />\n",
        "  <line x1=\"24\" y1=\"102\" x2=\"111\" y2=\"102\" />\n",
+       "  <line x1=\"24\" y1=\"124\" x2=\"111\" y2=\"124\" />\n",
        "  <line x1=\"24\" y1=\"134\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"46\" y1=\"14\" x2=\"46\" y2=\"134\" />\n",
        "  <line x1=\"68\" y1=\"14\" x2=\"68\" y2=\"134\" />\n",
+       "  <line x1=\"90\" y1=\"14\" x2=\"90\" y2=\"134\" />\n",
        "  <line x1=\"111\" y1=\"14\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3435,7 +3702,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-7e43670f-f5c5-4b4b-8c2d-fdd655c8dc4e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7e43670f-f5c5-4b4b-8c2d-fdd655c8dc4e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e7bcf987-38d7-4b30-8f76-3922605a703c' class='xr-var-data-in' type='checkbox'><label for='data-e7bcf987-38d7-4b30-8f76-3922605a703c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-5717c6d8-36f1-45b7-811f-a67999d03b97' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5717c6d8-36f1-45b7-811f-a67999d03b97' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e01ebf80-4ab8-4ced-8673-d3e645e0e62b' class='xr-var-data-in' type='checkbox'><label for='data-e01ebf80-4ab8-4ced-8673-d3e645e0e62b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3451,17 +3718,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.93 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (11, 5619, 4054) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 66 chunks in 12 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 264 chunks in 12 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -3475,8 +3742,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"21\" x2=\"24\" y2=\"36\" />\n",
        "  <line x1=\"10\" y1=\"43\" x2=\"24\" y2=\"58\" />\n",
+       "  <line x1=\"10\" y1=\"65\" x2=\"24\" y2=\"80\" />\n",
        "  <line x1=\"10\" y1=\"87\" x2=\"24\" y2=\"102\" />\n",
+       "  <line x1=\"10\" y1=\"109\" x2=\"24\" y2=\"124\" />\n",
        "  <line x1=\"10\" y1=\"120\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -3512,7 +3782,9 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"31\" y1=\"0\" x2=\"46\" y2=\"14\" />\n",
        "  <line x1=\"53\" y1=\"0\" x2=\"68\" y2=\"14\" />\n",
+       "  <line x1=\"75\" y1=\"0\" x2=\"90\" y2=\"14\" />\n",
        "  <line x1=\"96\" y1=\"0\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3520,13 +3792,18 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"36\" x2=\"111\" y2=\"36\" />\n",
        "  <line x1=\"24\" y1=\"58\" x2=\"111\" y2=\"58\" />\n",
+       "  <line x1=\"24\" y1=\"80\" x2=\"111\" y2=\"80\" />\n",
        "  <line x1=\"24\" y1=\"102\" x2=\"111\" y2=\"102\" />\n",
+       "  <line x1=\"24\" y1=\"124\" x2=\"111\" y2=\"124\" />\n",
        "  <line x1=\"24\" y1=\"134\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"46\" y1=\"14\" x2=\"46\" y2=\"134\" />\n",
        "  <line x1=\"68\" y1=\"14\" x2=\"68\" y2=\"134\" />\n",
+       "  <line x1=\"90\" y1=\"14\" x2=\"90\" y2=\"134\" />\n",
        "  <line x1=\"111\" y1=\"14\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3539,7 +3816,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 2048, 2048), meta=np.ndarray&gt;</div><input id='attrs-7e68fe05-0f6b-4daf-ad68-aacc397b4e91' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7e68fe05-0f6b-4daf-ad68-aacc397b4e91' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5ca7dcbc-736e-4694-b5c6-8ae394b92d75' class='xr-var-data-in' type='checkbox'><label for='data-5ca7dcbc-736e-4694-b5c6-8ae394b92d75' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-dd27a4ef-5861-475f-9812-ae6dfd02cb94' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-dd27a4ef-5861-475f-9812-ae6dfd02cb94' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2724bf23-80eb-4caf-b515-a5631f67710b' class='xr-var-data-in' type='checkbox'><label for='data-2724bf23-80eb-4caf-b515-a5631f67710b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3555,17 +3832,17 @@
        "                    <tr>\n",
        "                        <th> Bytes </th>\n",
        "                        <td> 0.93 GiB </td>\n",
-       "                        <td> 16.00 MiB </td>\n",
+       "                        <td> 4.00 MiB </td>\n",
        "                    </tr>\n",
        "                    \n",
        "                    <tr>\n",
        "                        <th> Shape </th>\n",
        "                        <td> (11, 5619, 4054) </td>\n",
-       "                        <td> (1, 2048, 2048) </td>\n",
+       "                        <td> (1, 1024, 1024) </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Dask graph </th>\n",
-       "                        <td colspan=\"2\"> 66 chunks in 12 graph layers </td>\n",
+       "                        <td colspan=\"2\"> 264 chunks in 12 graph layers </td>\n",
        "                    </tr>\n",
        "                    <tr>\n",
        "                        <th> Data type </th>\n",
@@ -3579,8 +3856,11 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"21\" x2=\"24\" y2=\"36\" />\n",
        "  <line x1=\"10\" y1=\"43\" x2=\"24\" y2=\"58\" />\n",
+       "  <line x1=\"10\" y1=\"65\" x2=\"24\" y2=\"80\" />\n",
        "  <line x1=\"10\" y1=\"87\" x2=\"24\" y2=\"102\" />\n",
+       "  <line x1=\"10\" y1=\"109\" x2=\"24\" y2=\"124\" />\n",
        "  <line x1=\"10\" y1=\"120\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
@@ -3616,7 +3896,9 @@
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"10\" y1=\"0\" x2=\"24\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"31\" y1=\"0\" x2=\"46\" y2=\"14\" />\n",
        "  <line x1=\"53\" y1=\"0\" x2=\"68\" y2=\"14\" />\n",
+       "  <line x1=\"75\" y1=\"0\" x2=\"90\" y2=\"14\" />\n",
        "  <line x1=\"96\" y1=\"0\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3624,13 +3906,18 @@
        "\n",
        "  <!-- Horizontal lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"111\" y2=\"14\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"24\" y1=\"36\" x2=\"111\" y2=\"36\" />\n",
        "  <line x1=\"24\" y1=\"58\" x2=\"111\" y2=\"58\" />\n",
+       "  <line x1=\"24\" y1=\"80\" x2=\"111\" y2=\"80\" />\n",
        "  <line x1=\"24\" y1=\"102\" x2=\"111\" y2=\"102\" />\n",
+       "  <line x1=\"24\" y1=\"124\" x2=\"111\" y2=\"124\" />\n",
        "  <line x1=\"24\" y1=\"134\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Vertical lines -->\n",
        "  <line x1=\"24\" y1=\"14\" x2=\"24\" y2=\"134\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"46\" y1=\"14\" x2=\"46\" y2=\"134\" />\n",
        "  <line x1=\"68\" y1=\"14\" x2=\"68\" y2=\"134\" />\n",
+       "  <line x1=\"90\" y1=\"14\" x2=\"90\" y2=\"134\" />\n",
        "  <line x1=\"111\" y1=\"14\" x2=\"111\" y2=\"134\" style=\"stroke-width:2\" />\n",
        "\n",
        "  <!-- Colored Rectangle -->\n",
@@ -3643,7 +3930,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, time, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 1, 13, 10), meta=np.ndarray&gt;</div><input id='attrs-4a04ffe2-d018-4eec-a2bf-4e0ed3227dae' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-4a04ffe2-d018-4eec-a2bf-4e0ed3227dae' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-620a5cc7-448e-4ca3-8c7d-62c2b2d5ba8b' class='xr-var-data-in' type='checkbox'><label for='data-620a5cc7-448e-4ca3-8c7d-62c2b2d5ba8b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, time, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 1, 13, 10), meta=np.ndarray&gt;</div><input id='attrs-562a189f-9c33-44f7-8afc-0401785aa7d4' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-562a189f-9c33-44f7-8afc-0401785aa7d4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ca8319a0-a930-470d-8af5-86075c837213' class='xr-var-data-in' type='checkbox'><label for='data-ca8319a0-a930-470d-8af5-86075c837213' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3757,7 +4044,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, time, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 1, 13, 10), meta=np.ndarray&gt;</div><input id='attrs-84c87396-2aa6-431e-9e31-5bce0b4cb4db' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-84c87396-2aa6-431e-9e31-5bce0b4cb4db' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-57d0b821-1025-4a73-a974-8ca5f60e6431' class='xr-var-data-in' type='checkbox'><label for='data-57d0b821-1025-4a73-a974-8ca5f60e6431' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, time, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 1, 13, 10), meta=np.ndarray&gt;</div><input id='attrs-d2746865-c020-4f55-b8ff-6ddf1f249430' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d2746865-c020-4f55-b8ff-6ddf1f249430' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b2cdebac-666e-467e-8ec6-f9038b6b2394' class='xr-var-data-in' type='checkbox'><label for='data-b2cdebac-666e-467e-8ec6-f9038b6b2394' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -3871,28 +4158,28 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-578b8db0-18c9-470e-95bb-2cb5ae9dca51' class='xr-section-summary-in' type='checkbox'  ><label for='section-578b8db0-18c9-470e-95bb-2cb5ae9dca51' class='xr-section-summary' >Indexes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-4cf75acd-07a9-4e5e-ad3b-2a6a39f3b8ea' class='xr-index-data-in' type='checkbox'/><label for='index-4cf75acd-07a9-4e5e-ad3b-2a6a39f3b8ea' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-15 10:15:59.024000&#x27;, &#x27;2020-07-16 10:40:31.024000&#x27;,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9c660931-b49a-496a-b695-34458ee5c62d' class='xr-section-summary-in' type='checkbox'  ><label for='section-9c660931-b49a-496a-b695-34458ee5c62d' class='xr-section-summary' >Indexes: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-caafe5db-39e5-429a-9168-9e0638edeebf' class='xr-index-data-in' type='checkbox'/><label for='index-caafe5db-39e5-429a-9168-9e0638edeebf' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-15 10:15:59.024000&#x27;, &#x27;2020-07-16 10:40:31.024000&#x27;,\n",
        "               &#x27;2020-07-18 10:25:59.024000&#x27;, &#x27;2020-07-20 10:20:31.024000&#x27;,\n",
        "               &#x27;2020-07-21 10:36:29.024000&#x27;, &#x27;2020-07-23 10:30:31.024000&#x27;,\n",
        "               &#x27;2020-07-25 10:15:59.024000&#x27;, &#x27;2020-07-26 10:40:31.024000&#x27;,\n",
        "               &#x27;2020-07-28 10:25:59.024000&#x27;, &#x27;2020-07-30 10:20:31.024000&#x27;,\n",
        "               &#x27;2020-07-31 10:36:29.024000&#x27;],\n",
-       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-34cbc805-180a-41e5-aa74-af4ba9fa3be5' class='xr-index-data-in' type='checkbox'/><label for='index-34cbc805-180a-41e5-aa74-af4ba9fa3be5' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([546105.0, 546115.0, 546125.0, 546135.0, 546145.0, 546155.0, 546165.0,\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-79ba318e-0345-44fd-bb4b-5af679f30caa' class='xr-index-data-in' type='checkbox'/><label for='index-79ba318e-0345-44fd-bb4b-5af679f30caa' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([546105.0, 546115.0, 546125.0, 546135.0, 546145.0, 546155.0, 546165.0,\n",
        "       546175.0, 546185.0, 546195.0,\n",
        "       ...\n",
        "       586545.0, 586555.0, 586565.0, 586575.0, 586585.0, 586595.0, 586605.0,\n",
        "       586615.0, 586625.0, 586635.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=4054))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-8a3a7ced-58d8-4a64-9995-766a02c6b980' class='xr-index-data-in' type='checkbox'/><label for='index-8a3a7ced-58d8-4a64-9995-766a02c6b980' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5962055.0, 5962045.0, 5962035.0, 5962025.0, 5962015.0, 5962005.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=4054))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-641f67a0-1267-4909-bc86-46311bc44315' class='xr-index-data-in' type='checkbox'/><label for='index-641f67a0-1267-4909-bc86-46311bc44315' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5962055.0, 5962045.0, 5962035.0, 5962025.0, 5962015.0, 5962005.0,\n",
        "       5961995.0, 5961985.0, 5961975.0, 5961965.0,\n",
        "       ...\n",
        "       5905965.0, 5905955.0, 5905945.0, 5905935.0, 5905925.0, 5905915.0,\n",
        "       5905905.0, 5905895.0, 5905885.0, 5905875.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=5619))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-71bdd393-c4cd-40ef-a017-58eb8f3bee51' class='xr-index-data-in' type='checkbox'/><label for='index-71bdd393-c4cd-40ef-a017-58eb8f3bee51' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([546105.0, 551105.0, 556105.0, 561105.0, 566105.0, 571105.0, 576105.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=5619))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-d4d815b6-16e9-4e0d-9cad-27e23ea258a0' class='xr-index-data-in' type='checkbox'/><label for='index-d4d815b6-16e9-4e0d-9cad-27e23ea258a0' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([546105.0, 551105.0, 556105.0, 561105.0, 566105.0, 571105.0, 576105.0,\n",
        "       581105.0, 586105.0, 591105.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-01d8a887-d8dc-4481-a8d1-c8148c1b70b7' class='xr-index-data-in' type='checkbox'/><label for='index-01d8a887-d8dc-4481-a8d1-c8148c1b70b7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5965875.0, 5960875.0, 5955875.0, 5950875.0, 5945875.0, 5940875.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-393284ed-6085-4635-ac0a-1e624302c0f3' class='xr-index-data-in' type='checkbox'/><label for='index-393284ed-6085-4635-ac0a-1e624302c0f3' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5965875.0, 5960875.0, 5955875.0, 5950875.0, 5945875.0, 5940875.0,\n",
        "       5935875.0, 5930875.0, 5925875.0, 5920875.0, 5915875.0, 5910875.0,\n",
        "       5905875.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-57175acc-52cb-4bca-abec-740eaf5879fb' class='xr-index-data-in' type='checkbox'/><label for='index-57175acc-52cb-4bca-abec-740eaf5879fb' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-8fdc2481-c7e8-47e7-8b37-6da78fd8a7a6' class='xr-index-data-in' type='checkbox'/><label for='index-8fdc2481-c7e8-47e7-8b37-6da78fd8a7a6' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-28120a21-e532-4114-a956-41afaf0362b5' class='xr-section-summary-in' type='checkbox'  ><label for='section-28120a21-e532-4114-a956-41afaf0362b5' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-15T10:15:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200715T101559_N0500_R065_T32UNE_20230423T052638&#x27;], &#x27;2020-07-16T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230410T110332&#x27;, &#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230325T195238&#x27;], &#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200718T102559_N0500_R108_T32UNE_20230425T043013&#x27;], &#x27;2020-07-20T10:20:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200720T102031_N0500_R065_T32UNE_20230501T182808&#x27;], &#x27;2020-07-21T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200721T103629_N0500_R008_T32UNE_20230614T014152&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200723T103031_N0500_R108_T32UNE_20230504T135307&#x27;], &#x27;2020-07-25T10:15:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200725T101559_N0500_R065_T32UNE_20230430T175257&#x27;], &#x27;2020-07-26T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200726T104031_N0500_R008_T32UNE_20230506T073348&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200728T102559_N0500_R108_T32UNE_20230505T111819&#x27;], &#x27;2020-07-30T10:20:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200730T102031_N0500_R065_T32UNE_20230414T031753&#x27;], &#x27;2020-07-31T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200731T103629_N0500_R008_T32UNE_20230523T160015&#x27;]}</dd><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-2ea53aca-92a8-4572-b59d-2805e94e85ba' class='xr-index-data-in' type='checkbox'/><label for='index-2ea53aca-92a8-4572-b59d-2805e94e85ba' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-df0a9ed7-e1c4-412b-ae6d-a05d85d210bc' class='xr-index-data-in' type='checkbox'/><label for='index-df0a9ed7-e1c4-412b-ae6d-a05d85d210bc' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e922a778-8ab4-41bb-93bf-9db2be050800' class='xr-section-summary-in' type='checkbox'  ><label for='section-e922a778-8ab4-41bb-93bf-9db2be050800' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-15T10:15:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200715T101559_N0500_R065_T32UNE_20230423T052638&#x27;], &#x27;2020-07-16T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230410T110332&#x27;, &#x27;S2A_MSIL2A_20200716T104031_N0500_R008_T32UNE_20230325T195238&#x27;], &#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200718T102559_N0500_R108_T32UNE_20230425T043013&#x27;], &#x27;2020-07-20T10:20:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200720T102031_N0500_R065_T32UNE_20230501T182808&#x27;], &#x27;2020-07-21T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200721T103629_N0500_R008_T32UNE_20230614T014152&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200723T103031_N0500_R108_T32UNE_20230504T135307&#x27;], &#x27;2020-07-25T10:15:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200725T101559_N0500_R065_T32UNE_20230430T175257&#x27;], &#x27;2020-07-26T10:40:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200726T104031_N0500_R008_T32UNE_20230506T073348&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200728T102559_N0500_R108_T32UNE_20230505T111819&#x27;], &#x27;2020-07-30T10:20:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200730T102031_N0500_R065_T32UNE_20230414T031753&#x27;], &#x27;2020-07-31T10:36:29.024000&#x27;: [&#x27;S2B_MSIL2A_20200731T103629_N0500_R008_T32UNE_20230523T160015&#x27;]}</dd><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 4GB\n",
@@ -3908,10 +4195,10 @@
        "  * angle          (angle) object 16B 'zenith' 'azimuth'\n",
        "  * band           (band) <U3 36B 'B02' 'B03' 'B04'\n",
        "Data variables:\n",
-       "    B02            (time, y, x) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    B03            (time, y, x) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    B04            (time, y, x) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
-       "    SCL            (time, y, x) float32 1GB dask.array<chunksize=(1, 2048, 2048), meta=np.ndarray>\n",
+       "    B02            (time, y, x) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    B03            (time, y, x) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    B04            (time, y, x) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
+       "    SCL            (time, y, x) float32 1GB dask.array<chunksize=(1, 1024, 1024), meta=np.ndarray>\n",
        "    solar_angle    (angle, time, angle_y, angle_x) float32 11kB dask.array<chunksize=(2, 1, 13, 10), meta=np.ndarray>\n",
        "    viewing_angle  (angle, band, time, angle_y, angle_x) float32 34kB dask.array<chunksize=(2, 3, 1, 13, 10), meta=np.ndarray>\n",
        "Attributes: (3)"
@@ -3952,8 +4239,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 8.95 s, sys: 582 ms, total: 9.54 s\n",
-      "Wall time: 10.4 s\n"
+      "CPU times: user 4.18 s, sys: 120 ms, total: 4.3 s\n",
+      "Wall time: 3.9 s\n"
      ]
     },
     {
@@ -3967,7 +4254,7 @@
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x772a472542d0>"
+       "<matplotlib.collections.QuadMesh at 0x73654d1d82d0>"
       ]
      },
      "execution_count": 14,
@@ -3997,9 +4284,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "----\n",
-    "## Data store to access single observations\n",
-    "Now, we initiate the data store to access each STAC item representing one observation tile. "
+    "### Fast timeseries cube generation (single-tile mode)\n",
+    "\n",
+    "There is also a timeseries mode available that generates a time series cube from a single Sentinel-2 tile. Instead of providing `bbox` and `crs`, you now supply a `point` (lon, lat) together with a `bbox_width` in meters (must be < 10,000). The system will cut out a region around the given point, restricted to a single tile and native crs, and stack it along the time dimension. This improves cube generation performance. \n",
+    "\n",
+    "Below we again view the `open_params`, where the second group shows the parameters needed to trigger the single-tile mode. "
    ]
   },
   {
@@ -4011,8 +4300,1249 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 11.3 ms, sys: 4.03 ms, total: 15.3 ms\n",
-      "Wall time: 104 ms\n"
+      "CPU times: user 10.2 ms, sys: 5 μs, total: 10.2 ms\n",
+      "Wall time: 9.44 ms\n"
+     ]
+    },
+    {
+     "data": {
+      "application/json": {
+       "oneOf": [
+        {
+         "additionalProperties": false,
+         "properties": {
+          "add_angles": {
+           "default": false,
+           "description": "Viewing and solar angles will be extracted for all spectral bands defined in keyword `asset_name`.",
+           "title": "Add viewing and solar angles from Sentinel2 metadata.",
+           "type": "boolean"
+          },
+          "apply_scaling": {
+           "default": true,
+           "title": "Apply scaling, offset, and no-data values to data.",
+           "type": "boolean"
+          },
+          "asset_names": {
+           "items": {
+            "enum": [
+             "B01",
+             "B02",
+             "B03",
+             "B04",
+             "B05",
+             "B06",
+             "B07",
+             "B08",
+             "B8A",
+             "B09",
+             "B11",
+             "B12",
+             "AOT",
+             "SCL",
+             "WVP"
+            ],
+            "minLength": 1,
+            "type": "string"
+           },
+           "title": "Names of assets (spectral bands)",
+           "type": "array",
+           "uniqueItems": true
+          },
+          "bbox": {
+           "items": [
+            {
+             "type": "number"
+            },
+            {
+             "type": "number"
+            },
+            {
+             "type": "number"
+            },
+            {
+             "type": "number"
+            }
+           ],
+           "title": "Bounding box [x1,y1,x2,y2] in coordinates of the given CRS.",
+           "type": "array"
+          },
+          "crs": {
+           "default": "EPSG:4326",
+           "title": "Coordinate reference system",
+           "type": "string"
+          },
+          "query": {
+           "additionalProperties": true,
+           "description": "If STAC Catalog is conform with query extension, additional filtering based on the properties of Item objects is supported. For more information see https://github.com/stac-api-extensions/query",
+           "properties": {},
+           "title": "Additional query options used during item search of STAC API.",
+           "type": "object"
+          },
+          "spatial_res": {
+           "exclusiveMinimum": 0,
+           "title": "Spatial Resolution",
+           "type": "number"
+          },
+          "tile_size": {
+           "default": 1024,
+           "description": "Either a tuple asigning width and height (x, y), or single int for quadratic chunk size.",
+           "oneOf": [
+            {
+             "minimum": 256,
+             "type": "number"
+            },
+            {
+             "items": [
+              {
+               "minimum": 256,
+               "type": "number"
+              },
+              {
+               "minimum": 256,
+               "type": "number"
+              }
+             ],
+             "type": "array"
+            }
+           ],
+           "title": "Spatial chunk size"
+          },
+          "time_range": {
+           "description": "Time range given as pair of start and stop dates. Dates must be given using format 'YYYY-MM-DD'. Start and stop are inclusive.",
+           "items": [
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            },
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            }
+           ],
+           "title": "Time Range",
+           "type": "array"
+          }
+         },
+         "required": [
+          "time_range",
+          "bbox",
+          "spatial_res",
+          "crs"
+         ],
+         "title": "Open parameters to open via a user-defined bounding box.",
+         "type": "object"
+        },
+        {
+         "additionalProperties": false,
+         "properties": {
+          "add_angles": {
+           "default": false,
+           "description": "Viewing and solar angles will be extracted for all spectral bands defined in keyword `asset_name`.",
+           "title": "Add viewing and solar angles from Sentinel2 metadata.",
+           "type": "boolean"
+          },
+          "apply_scaling": {
+           "default": true,
+           "title": "Apply scaling, offset, and no-data values to data.",
+           "type": "boolean"
+          },
+          "asset_names": {
+           "items": {
+            "enum": [
+             "B01",
+             "B02",
+             "B03",
+             "B04",
+             "B05",
+             "B06",
+             "B07",
+             "B08",
+             "B8A",
+             "B09",
+             "B11",
+             "B12",
+             "AOT",
+             "SCL",
+             "WVP"
+            ],
+            "minLength": 1,
+            "type": "string"
+           },
+           "title": "Names of assets (spectral bands)",
+           "type": "array",
+           "uniqueItems": true
+          },
+          "bbox_width": {
+           "exclusiveMinimum": 0,
+           "maximum": 10000,
+           "title": "Full width of bounding box in meter, aligned around the coordinates given in `point`.",
+           "type": "number"
+          },
+          "point": {
+           "items": [
+            {
+             "maximum": 180,
+             "minimum": -180,
+             "type": "number"
+            },
+            {
+             "maximum": 90,
+             "minimum": -90,
+             "type": "number"
+            }
+           ],
+           "title": "Point given in (lon, lat) in geographical coordinates.",
+           "type": "array"
+          },
+          "query": {
+           "additionalProperties": true,
+           "description": "If STAC Catalog is conform with query extension, additional filtering based on the properties of Item objects is supported. For more information see https://github.com/stac-api-extensions/query",
+           "properties": {},
+           "title": "Additional query options used during item search of STAC API.",
+           "type": "object"
+          },
+          "spatial_res": {
+           "default": 10,
+           "enum": [
+            10,
+            20,
+            60
+           ],
+           "title": "Spatial Resolution",
+           "type": "number"
+          },
+          "tile_size": {
+           "default": 1024,
+           "description": "Either a tuple asigning width and height (x, y), or single int for quadratic chunk size.",
+           "oneOf": [
+            {
+             "minimum": 256,
+             "type": "number"
+            },
+            {
+             "items": [
+              {
+               "minimum": 256,
+               "type": "number"
+              },
+              {
+               "minimum": 256,
+               "type": "number"
+              }
+             ],
+             "type": "array"
+            }
+           ],
+           "title": "Spatial chunk size"
+          },
+          "time_range": {
+           "description": "Time range given as pair of start and stop dates. Dates must be given using format 'YYYY-MM-DD'. Start and stop are inclusive.",
+           "items": [
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            },
+            {
+             "format": "date",
+             "type": [
+              "string",
+              "null"
+             ]
+            }
+           ],
+           "title": "Time Range",
+           "type": "array"
+          }
+         },
+         "required": [
+          "time_range",
+          "point",
+          "spatial_res",
+          "bbox_width"
+         ],
+         "title": "Open parameters to generate a cube cutout around a given `point`.",
+         "type": "object"
+        }
+       ]
+      },
+      "text/plain": [
+       "<xcube.util.jsonschema.JsonComplexSchema at 0x73654fbddb50>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "store.get_open_data_params_schema(data_id=\"sentinel-2-l2a\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 409 ms, sys: 41 ms, total: 450 ms\n",
+      "Wall time: 2.41 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div><svg style=\"position: absolute; width: 0; height: 0; overflow: hidden\">\n",
+       "<defs>\n",
+       "<symbol id=\"icon-database\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M16 0c-8.837 0-16 2.239-16 5v4c0 2.761 7.163 5 16 5s16-2.239 16-5v-4c0-2.761-7.163-5-16-5z\"></path>\n",
+       "<path d=\"M16 17c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "<path d=\"M16 26c-8.837 0-16-2.239-16-5v6c0 2.761 7.163 5 16 5s16-2.239 16-5v-6c0 2.761-7.163 5-16 5z\"></path>\n",
+       "</symbol>\n",
+       "<symbol id=\"icon-file-text2\" viewBox=\"0 0 32 32\">\n",
+       "<path d=\"M28.681 7.159c-0.694-0.947-1.662-2.053-2.724-3.116s-2.169-2.030-3.116-2.724c-1.612-1.182-2.393-1.319-2.841-1.319h-15.5c-1.378 0-2.5 1.121-2.5 2.5v27c0 1.378 1.122 2.5 2.5 2.5h23c1.378 0 2.5-1.122 2.5-2.5v-19.5c0-0.448-0.137-1.23-1.319-2.841zM24.543 5.457c0.959 0.959 1.712 1.825 2.268 2.543h-4.811v-4.811c0.718 0.556 1.584 1.309 2.543 2.268zM28 29.5c0 0.271-0.229 0.5-0.5 0.5h-23c-0.271 0-0.5-0.229-0.5-0.5v-27c0-0.271 0.229-0.5 0.5-0.5 0 0 15.499-0 15.5 0v7c0 0.552 0.448 1 1 1h7v19.5z\"></path>\n",
+       "<path d=\"M23 26h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 22h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "<path d=\"M23 18h-14c-0.552 0-1-0.448-1-1s0.448-1 1-1h14c0.552 0 1 0.448 1 1s-0.448 1-1 1z\"></path>\n",
+       "</symbol>\n",
+       "</defs>\n",
+       "</svg>\n",
+       "<style>/* CSS stylesheet for displaying xarray objects in jupyterlab.\n",
+       " *\n",
+       " */\n",
+       "\n",
+       ":root {\n",
+       "  --xr-font-color0: var(\n",
+       "    --jp-content-font-color0,\n",
+       "    var(--pst-color-text-base rgba(0, 0, 0, 1))\n",
+       "  );\n",
+       "  --xr-font-color2: var(\n",
+       "    --jp-content-font-color2,\n",
+       "    var(--pst-color-text-base, rgba(0, 0, 0, 0.54))\n",
+       "  );\n",
+       "  --xr-font-color3: var(\n",
+       "    --jp-content-font-color3,\n",
+       "    var(--pst-color-text-base, rgba(0, 0, 0, 0.38))\n",
+       "  );\n",
+       "  --xr-border-color: var(\n",
+       "    --jp-border-color2,\n",
+       "    hsl(from var(--pst-color-on-background, white) h s calc(l - 10))\n",
+       "  );\n",
+       "  --xr-disabled-color: var(\n",
+       "    --jp-layout-color3,\n",
+       "    hsl(from var(--pst-color-on-background, white) h s calc(l - 40))\n",
+       "  );\n",
+       "  --xr-background-color: var(\n",
+       "    --jp-layout-color0,\n",
+       "    var(--pst-color-on-background, white)\n",
+       "  );\n",
+       "  --xr-background-color-row-even: var(\n",
+       "    --jp-layout-color1,\n",
+       "    hsl(from var(--pst-color-on-background, white) h s calc(l - 5))\n",
+       "  );\n",
+       "  --xr-background-color-row-odd: var(\n",
+       "    --jp-layout-color2,\n",
+       "    hsl(from var(--pst-color-on-background, white) h s calc(l - 15))\n",
+       "  );\n",
+       "}\n",
+       "\n",
+       "html[theme=\"dark\"],\n",
+       "html[data-theme=\"dark\"],\n",
+       "body[data-theme=\"dark\"],\n",
+       "body.vscode-dark {\n",
+       "  --xr-font-color0: var(\n",
+       "    --jp-content-font-color0,\n",
+       "    var(--pst-color-text-base, rgba(255, 255, 255, 1))\n",
+       "  );\n",
+       "  --xr-font-color2: var(\n",
+       "    --jp-content-font-color2,\n",
+       "    var(--pst-color-text-base, rgba(255, 255, 255, 0.54))\n",
+       "  );\n",
+       "  --xr-font-color3: var(\n",
+       "    --jp-content-font-color3,\n",
+       "    var(--pst-color-text-base, rgba(255, 255, 255, 0.38))\n",
+       "  );\n",
+       "  --xr-border-color: var(\n",
+       "    --jp-border-color2,\n",
+       "    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 10))\n",
+       "  );\n",
+       "  --xr-disabled-color: var(\n",
+       "    --jp-layout-color3,\n",
+       "    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 40))\n",
+       "  );\n",
+       "  --xr-background-color: var(\n",
+       "    --jp-layout-color0,\n",
+       "    var(--pst-color-on-background, #111111)\n",
+       "  );\n",
+       "  --xr-background-color-row-even: var(\n",
+       "    --jp-layout-color1,\n",
+       "    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 5))\n",
+       "  );\n",
+       "  --xr-background-color-row-odd: var(\n",
+       "    --jp-layout-color2,\n",
+       "    hsl(from var(--pst-color-on-background, #111111) h s calc(l + 15))\n",
+       "  );\n",
+       "}\n",
+       "\n",
+       ".xr-wrap {\n",
+       "  display: block !important;\n",
+       "  min-width: 300px;\n",
+       "  max-width: 700px;\n",
+       "}\n",
+       "\n",
+       ".xr-text-repr-fallback {\n",
+       "  /* fallback to plain text repr when CSS is not injected (untrusted notebook) */\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-header {\n",
+       "  padding-top: 6px;\n",
+       "  padding-bottom: 6px;\n",
+       "  margin-bottom: 4px;\n",
+       "  border-bottom: solid 1px var(--xr-border-color);\n",
+       "}\n",
+       "\n",
+       ".xr-header > div,\n",
+       ".xr-header > ul {\n",
+       "  display: inline;\n",
+       "  margin-top: 0;\n",
+       "  margin-bottom: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type,\n",
+       ".xr-array-name {\n",
+       "  margin-left: 2px;\n",
+       "  margin-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-obj-type {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-sections {\n",
+       "  padding-left: 0 !important;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 150px auto auto 1fr 0 20px 0 20px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input {\n",
+       "  display: inline-block;\n",
+       "  opacity: 0;\n",
+       "  height: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input + label {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "  border: 2px solid transparent !important;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label {\n",
+       "  cursor: pointer;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:focus + label {\n",
+       "  border: 2px solid var(--xr-font-color0) !important;\n",
+       "}\n",
+       "\n",
+       ".xr-section-item input:enabled + label:hover {\n",
+       "  color: var(--xr-font-color0);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary {\n",
+       "  grid-column: 1;\n",
+       "  color: var(--xr-font-color2);\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary > span {\n",
+       "  display: inline-block;\n",
+       "  padding-left: 0.5em;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label {\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in + label:before {\n",
+       "  display: inline-block;\n",
+       "  content: \"►\";\n",
+       "  font-size: 11px;\n",
+       "  width: 15px;\n",
+       "  text-align: center;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:disabled + label:before {\n",
+       "  color: var(--xr-disabled-color);\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label:before {\n",
+       "  content: \"▼\";\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked + label > span {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary,\n",
+       ".xr-section-inline-details {\n",
+       "  padding-top: 4px;\n",
+       "  padding-bottom: 4px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-inline-details {\n",
+       "  grid-column: 2 / -1;\n",
+       "}\n",
+       "\n",
+       ".xr-section-details {\n",
+       "  display: none;\n",
+       "  grid-column: 1 / -1;\n",
+       "  margin-bottom: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-section-summary-in:checked ~ .xr-section-details {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap {\n",
+       "  grid-column: 1 / -1;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 20px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-array-wrap > label {\n",
+       "  grid-column: 1;\n",
+       "  vertical-align: top;\n",
+       "}\n",
+       "\n",
+       ".xr-preview {\n",
+       "  color: var(--xr-font-color3);\n",
+       "}\n",
+       "\n",
+       ".xr-array-preview,\n",
+       ".xr-array-data {\n",
+       "  padding: 0 5px !important;\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-array-data,\n",
+       ".xr-array-in:checked ~ .xr-array-preview {\n",
+       "  display: none;\n",
+       "}\n",
+       "\n",
+       ".xr-array-in:checked ~ .xr-array-data,\n",
+       ".xr-array-preview {\n",
+       "  display: inline-block;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list {\n",
+       "  display: inline-block !important;\n",
+       "  list-style: none;\n",
+       "  padding: 0 !important;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li {\n",
+       "  display: inline-block;\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:before {\n",
+       "  content: \"(\";\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list:after {\n",
+       "  content: \")\";\n",
+       "}\n",
+       "\n",
+       ".xr-dim-list li:not(:last-child):after {\n",
+       "  content: \",\";\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-has-index {\n",
+       "  font-weight: bold;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list,\n",
+       ".xr-var-item {\n",
+       "  display: contents;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > div,\n",
+       ".xr-var-item label,\n",
+       ".xr-var-item > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-even);\n",
+       "  border-color: var(--xr-background-color-row-odd);\n",
+       "  margin-bottom: 0;\n",
+       "  padding-top: 2px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-item > .xr-var-name:hover span {\n",
+       "  padding-right: 5px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-list > li:nth-child(odd) > div,\n",
+       ".xr-var-list > li:nth-child(odd) > label,\n",
+       ".xr-var-list > li:nth-child(odd) > .xr-var-name span {\n",
+       "  background-color: var(--xr-background-color-row-odd);\n",
+       "  border-color: var(--xr-background-color-row-even);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name {\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dims {\n",
+       "  grid-column: 2;\n",
+       "}\n",
+       "\n",
+       ".xr-var-dtype {\n",
+       "  grid-column: 3;\n",
+       "  text-align: right;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-preview {\n",
+       "  grid-column: 4;\n",
+       "}\n",
+       "\n",
+       ".xr-index-preview {\n",
+       "  grid-column: 2 / 5;\n",
+       "  color: var(--xr-font-color2);\n",
+       "}\n",
+       "\n",
+       ".xr-var-name,\n",
+       ".xr-var-dims,\n",
+       ".xr-var-dtype,\n",
+       ".xr-preview,\n",
+       ".xr-attrs dt {\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name:hover,\n",
+       ".xr-var-dims:hover,\n",
+       ".xr-var-dtype:hover,\n",
+       ".xr-attrs dt:hover {\n",
+       "  overflow: visible;\n",
+       "  width: auto;\n",
+       "  z-index: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data,\n",
+       ".xr-index-data {\n",
+       "  display: none;\n",
+       "  border-top: 2px dotted var(--xr-background-color);\n",
+       "  padding-bottom: 20px !important;\n",
+       "  padding-top: 10px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in + label,\n",
+       ".xr-var-data-in + label,\n",
+       ".xr-index-data-in + label {\n",
+       "  padding: 0 1px;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in:checked ~ .xr-var-attrs,\n",
+       ".xr-var-data-in:checked ~ .xr-var-data,\n",
+       ".xr-index-data-in:checked ~ .xr-index-data {\n",
+       "  display: block;\n",
+       "}\n",
+       "\n",
+       ".xr-var-data > table {\n",
+       "  float: right;\n",
+       "}\n",
+       "\n",
+       ".xr-var-data > pre,\n",
+       ".xr-index-data > pre,\n",
+       ".xr-var-data > table > tbody > tr {\n",
+       "  background-color: transparent !important;\n",
+       "}\n",
+       "\n",
+       ".xr-var-name span,\n",
+       ".xr-var-data,\n",
+       ".xr-index-name div,\n",
+       ".xr-index-data,\n",
+       ".xr-attrs {\n",
+       "  padding-left: 25px !important;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs,\n",
+       ".xr-var-attrs,\n",
+       ".xr-var-data,\n",
+       ".xr-index-data {\n",
+       "  grid-column: 1 / -1;\n",
+       "}\n",
+       "\n",
+       "dl.xr-attrs {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  display: grid;\n",
+       "  grid-template-columns: 125px auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt,\n",
+       ".xr-attrs dd {\n",
+       "  padding: 0;\n",
+       "  margin: 0;\n",
+       "  float: left;\n",
+       "  padding-right: 10px;\n",
+       "  width: auto;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt {\n",
+       "  font-weight: normal;\n",
+       "  grid-column: 1;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dt:hover span {\n",
+       "  display: inline-block;\n",
+       "  background: var(--xr-background-color);\n",
+       "  padding-right: 10px;\n",
+       "}\n",
+       "\n",
+       ".xr-attrs dd {\n",
+       "  grid-column: 2;\n",
+       "  white-space: pre-wrap;\n",
+       "  word-break: break-all;\n",
+       "}\n",
+       "\n",
+       ".xr-icon-database,\n",
+       ".xr-icon-file-text2,\n",
+       ".xr-no-icon {\n",
+       "  display: inline-block;\n",
+       "  vertical-align: middle;\n",
+       "  width: 1em;\n",
+       "  height: 1.5em !important;\n",
+       "  stroke-width: 0;\n",
+       "  stroke: currentColor;\n",
+       "  fill: currentColor;\n",
+       "}\n",
+       "\n",
+       ".xr-var-attrs-in:checked + label > .xr-icon-file-text2,\n",
+       ".xr-var-data-in:checked + label > .xr-icon-database,\n",
+       ".xr-index-data-in:checked + label > .xr-icon-database {\n",
+       "  color: var(--xr-font-color0);\n",
+       "  filter: drop-shadow(1px 1px 5px var(--xr-font-color2));\n",
+       "  stroke-width: 0.8px;\n",
+       "}\n",
+       "</style><pre class='xr-text-repr-fallback'>&lt;xarray.Dataset&gt; Size: 482kB\n",
+       "Dimensions:      (time: 3, y: 100, x: 100)\n",
+       "Coordinates:\n",
+       "  * x            (x) float64 800B 5.861e+05 5.862e+05 ... 5.871e+05 5.871e+05\n",
+       "  * y            (y) float64 800B 5.907e+06 5.907e+06 ... 5.906e+06 5.906e+06\n",
+       "    spatial_ref  int64 8B 0\n",
+       "  * time         (time) datetime64[ns] 24B 2020-07-18T10:25:59.024000 ... 202...\n",
+       "Data variables:\n",
+       "    B02          (time, y, x) float32 120kB dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;\n",
+       "    B03          (time, y, x) float32 120kB dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;\n",
+       "    B04          (time, y, x) float32 120kB dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;\n",
+       "    SCL          (time, y, x) float32 120kB dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;\n",
+       "Attributes: (4)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-0a0939ec-2971-4b17-9db5-fc6b5b6d20d7' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-0a0939ec-2971-4b17-9db5-fc6b5b6d20d7' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>time</span>: 3</li><li><span class='xr-has-index'>y</span>: 100</li><li><span class='xr-has-index'>x</span>: 100</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-23d49a0f-a22b-495f-896f-45c30963f0a0' class='xr-section-summary-in' type='checkbox'  checked><label for='section-23d49a0f-a22b-495f-896f-45c30963f0a0' class='xr-section-summary' >Coordinates: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.861e+05 5.862e+05 ... 5.871e+05</div><input id='attrs-0d33ca81-65c1-4796-a8e4-fc18ae6f190d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0d33ca81-65c1-4796-a8e4-fc18ae6f190d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3839be44-fbc8-4085-ba36-67d027ce2a8a' class='xr-var-data-in' type='checkbox'><label for='data-3839be44-fbc8-4085-ba36-67d027ce2a8a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([586145., 586155., 586165., 586175., 586185., 586195., 586205., 586215.,\n",
+       "       586225., 586235., 586245., 586255., 586265., 586275., 586285., 586295.,\n",
+       "       586305., 586315., 586325., 586335., 586345., 586355., 586365., 586375.,\n",
+       "       586385., 586395., 586405., 586415., 586425., 586435., 586445., 586455.,\n",
+       "       586465., 586475., 586485., 586495., 586505., 586515., 586525., 586535.,\n",
+       "       586545., 586555., 586565., 586575., 586585., 586595., 586605., 586615.,\n",
+       "       586625., 586635., 586645., 586655., 586665., 586675., 586685., 586695.,\n",
+       "       586705., 586715., 586725., 586735., 586745., 586755., 586765., 586775.,\n",
+       "       586785., 586795., 586805., 586815., 586825., 586835., 586845., 586855.,\n",
+       "       586865., 586875., 586885., 586895., 586905., 586915., 586925., 586935.,\n",
+       "       586945., 586955., 586965., 586975., 586985., 586995., 587005., 587015.,\n",
+       "       587025., 587035., 587045., 587055., 587065., 587075., 587085., 587095.,\n",
+       "       587105., 587115., 587125., 587135.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.907e+06 5.907e+06 ... 5.906e+06</div><input id='attrs-df73d284-61d6-437f-8bff-3e27cc7f3e92' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-df73d284-61d6-437f-8bff-3e27cc7f3e92' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-99081013-e18a-4b4c-9ab7-ed56e78a031a' class='xr-var-data-in' type='checkbox'><label for='data-99081013-e18a-4b4c-9ab7-ed56e78a031a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5906925., 5906915., 5906905., 5906895., 5906885., 5906875., 5906865.,\n",
+       "       5906855., 5906845., 5906835., 5906825., 5906815., 5906805., 5906795.,\n",
+       "       5906785., 5906775., 5906765., 5906755., 5906745., 5906735., 5906725.,\n",
+       "       5906715., 5906705., 5906695., 5906685., 5906675., 5906665., 5906655.,\n",
+       "       5906645., 5906635., 5906625., 5906615., 5906605., 5906595., 5906585.,\n",
+       "       5906575., 5906565., 5906555., 5906545., 5906535., 5906525., 5906515.,\n",
+       "       5906505., 5906495., 5906485., 5906475., 5906465., 5906455., 5906445.,\n",
+       "       5906435., 5906425., 5906415., 5906405., 5906395., 5906385., 5906375.,\n",
+       "       5906365., 5906355., 5906345., 5906335., 5906325., 5906315., 5906305.,\n",
+       "       5906295., 5906285., 5906275., 5906265., 5906255., 5906245., 5906235.,\n",
+       "       5906225., 5906215., 5906205., 5906195., 5906185., 5906175., 5906165.,\n",
+       "       5906155., 5906145., 5906135., 5906125., 5906115., 5906105., 5906095.,\n",
+       "       5906085., 5906075., 5906065., 5906055., 5906045., 5906035., 5906025.,\n",
+       "       5906015., 5906005., 5905995., 5905985., 5905975., 5905965., 5905955.,\n",
+       "       5905945., 5905935.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-57dc76ac-78d0-4dc9-b362-57e8f862919a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-57dc76ac-78d0-4dc9-b362-57e8f862919a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cade9683-a7b9-4cd9-842d-2647a997d635' class='xr-var-data-in' type='checkbox'><label for='data-cade9683-a7b9-4cd9-842d-2647a997d635' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>time</span></div><div class='xr-var-dims'>(time)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2020-07-18T10:25:59.024000 ... 2...</div><input id='attrs-bb21dc6d-ee7d-4cf1-a852-4d92a51cec14' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bb21dc6d-ee7d-4cf1-a852-4d92a51cec14' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4649fc49-0db4-4f9b-a471-b67e82ae8490' class='xr-var-data-in' type='checkbox'><label for='data-4649fc49-0db4-4f9b-a471-b67e82ae8490' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2020-07-18T10:25:59.024000000&#x27;, &#x27;2020-07-23T10:30:31.024000000&#x27;,\n",
+       "       &#x27;2020-07-28T10:25:59.024000000&#x27;], dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-6cba6e50-34e0-4af0-81fe-6748faa448b4' class='xr-section-summary-in' type='checkbox'  checked><label for='section-6cba6e50-34e0-4af0-81fe-6748faa448b4' class='xr-section-summary' >Data variables: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-8a522ed2-4efa-4c20-b088-b4c0a2bc0ee8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8a522ed2-4efa-4c20-b088-b4c0a2bc0ee8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-9e3bd377-0861-46a2-af20-65ae8fdccf27' class='xr-var-data-in' type='checkbox'><label for='data-9e3bd377-0861-46a2-af20-65ae8fdccf27' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    <tr>\n",
+       "        <td>\n",
+       "            <table style=\"border-collapse: collapse;\">\n",
+       "                <thead>\n",
+       "                    <tr>\n",
+       "                        <td> </td>\n",
+       "                        <th> Array </th>\n",
+       "                        <th> Chunk </th>\n",
+       "                    </tr>\n",
+       "                </thead>\n",
+       "                <tbody>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Bytes </th>\n",
+       "                        <td> 117.19 kiB </td>\n",
+       "                        <td> 39.06 kiB </td>\n",
+       "                    </tr>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Shape </th>\n",
+       "                        <td> (3, 100, 100) </td>\n",
+       "                        <td> (1, 100, 100) </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Dask graph </th>\n",
+       "                        <td colspan=\"2\"> 3 chunks in 29 graph layers </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Data type </th>\n",
+       "                        <td colspan=\"2\"> float32 numpy.ndarray </td>\n",
+       "                    </tr>\n",
+       "                </tbody>\n",
+       "            </table>\n",
+       "        </td>\n",
+       "        <td>\n",
+       "        <svg width=\"198\" height=\"188\" style=\"stroke:rgb(0,0,0);stroke-width:1\" >\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"120\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"10\" y2=\"120\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"16\" y2=\"126\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"22\" y2=\"132\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 28.46492855066211,18.46492855066211 28.46492855066211,138.4649285506621 10.0,120.0\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"136\" y2=\"6\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"142\" y2=\"12\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"130\" y1=\"0\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 130.0,0.0 148.4649285506621,18.46492855066211 28.46492855066211,18.46492855066211\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"138\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"148\" y1=\"18\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"28.46492855066211,18.46492855066211 148.4649285506621,18.46492855066211 148.4649285506621,138.4649285506621 28.46492855066211,138.4649285506621\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Text -->\n",
+       "  <text x=\"88.464929\" y=\"158.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >100</text>\n",
+       "  <text x=\"168.464929\" y=\"78.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,168.464929,78.464929)\">100</text>\n",
+       "  <text x=\"9.232464\" y=\"149.232464\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,9.232464,149.232464)\">3</text>\n",
+       "</svg>\n",
+       "        </td>\n",
+       "    </tr>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-f826d5dc-6055-4f0b-9768-1fbf8fcf8ccb' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f826d5dc-6055-4f0b-9768-1fbf8fcf8ccb' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f7046bed-2071-4788-93d1-08de9a9dc70f' class='xr-var-data-in' type='checkbox'><label for='data-f7046bed-2071-4788-93d1-08de9a9dc70f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    <tr>\n",
+       "        <td>\n",
+       "            <table style=\"border-collapse: collapse;\">\n",
+       "                <thead>\n",
+       "                    <tr>\n",
+       "                        <td> </td>\n",
+       "                        <th> Array </th>\n",
+       "                        <th> Chunk </th>\n",
+       "                    </tr>\n",
+       "                </thead>\n",
+       "                <tbody>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Bytes </th>\n",
+       "                        <td> 117.19 kiB </td>\n",
+       "                        <td> 39.06 kiB </td>\n",
+       "                    </tr>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Shape </th>\n",
+       "                        <td> (3, 100, 100) </td>\n",
+       "                        <td> (1, 100, 100) </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Dask graph </th>\n",
+       "                        <td colspan=\"2\"> 3 chunks in 29 graph layers </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Data type </th>\n",
+       "                        <td colspan=\"2\"> float32 numpy.ndarray </td>\n",
+       "                    </tr>\n",
+       "                </tbody>\n",
+       "            </table>\n",
+       "        </td>\n",
+       "        <td>\n",
+       "        <svg width=\"198\" height=\"188\" style=\"stroke:rgb(0,0,0);stroke-width:1\" >\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"120\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"10\" y2=\"120\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"16\" y2=\"126\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"22\" y2=\"132\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 28.46492855066211,18.46492855066211 28.46492855066211,138.4649285506621 10.0,120.0\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"136\" y2=\"6\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"142\" y2=\"12\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"130\" y1=\"0\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 130.0,0.0 148.4649285506621,18.46492855066211 28.46492855066211,18.46492855066211\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"138\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"148\" y1=\"18\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"28.46492855066211,18.46492855066211 148.4649285506621,18.46492855066211 148.4649285506621,138.4649285506621 28.46492855066211,138.4649285506621\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Text -->\n",
+       "  <text x=\"88.464929\" y=\"158.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >100</text>\n",
+       "  <text x=\"168.464929\" y=\"78.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,168.464929,78.464929)\">100</text>\n",
+       "  <text x=\"9.232464\" y=\"149.232464\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,9.232464,149.232464)\">3</text>\n",
+       "</svg>\n",
+       "        </td>\n",
+       "    </tr>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-64de12a6-ddae-4901-9363-cb55c2c43640' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-64de12a6-ddae-4901-9363-cb55c2c43640' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-687e7a4e-0b33-450f-8af4-e14a03da538d' class='xr-var-data-in' type='checkbox'><label for='data-687e7a4e-0b33-450f-8af4-e14a03da538d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    <tr>\n",
+       "        <td>\n",
+       "            <table style=\"border-collapse: collapse;\">\n",
+       "                <thead>\n",
+       "                    <tr>\n",
+       "                        <td> </td>\n",
+       "                        <th> Array </th>\n",
+       "                        <th> Chunk </th>\n",
+       "                    </tr>\n",
+       "                </thead>\n",
+       "                <tbody>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Bytes </th>\n",
+       "                        <td> 117.19 kiB </td>\n",
+       "                        <td> 39.06 kiB </td>\n",
+       "                    </tr>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Shape </th>\n",
+       "                        <td> (3, 100, 100) </td>\n",
+       "                        <td> (1, 100, 100) </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Dask graph </th>\n",
+       "                        <td colspan=\"2\"> 3 chunks in 29 graph layers </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Data type </th>\n",
+       "                        <td colspan=\"2\"> float32 numpy.ndarray </td>\n",
+       "                    </tr>\n",
+       "                </tbody>\n",
+       "            </table>\n",
+       "        </td>\n",
+       "        <td>\n",
+       "        <svg width=\"198\" height=\"188\" style=\"stroke:rgb(0,0,0);stroke-width:1\" >\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"120\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"10\" y2=\"120\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"16\" y2=\"126\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"22\" y2=\"132\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 28.46492855066211,18.46492855066211 28.46492855066211,138.4649285506621 10.0,120.0\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"136\" y2=\"6\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"142\" y2=\"12\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"130\" y1=\"0\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 130.0,0.0 148.4649285506621,18.46492855066211 28.46492855066211,18.46492855066211\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"138\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"148\" y1=\"18\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"28.46492855066211,18.46492855066211 148.4649285506621,18.46492855066211 148.4649285506621,138.4649285506621 28.46492855066211,138.4649285506621\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Text -->\n",
+       "  <text x=\"88.464929\" y=\"158.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >100</text>\n",
+       "  <text x=\"168.464929\" y=\"78.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,168.464929,78.464929)\">100</text>\n",
+       "  <text x=\"9.232464\" y=\"149.232464\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,9.232464,149.232464)\">3</text>\n",
+       "</svg>\n",
+       "        </td>\n",
+       "    </tr>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(time, y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 100, 100), meta=np.ndarray&gt;</div><input id='attrs-245314dd-46fb-4798-b18d-0d27049cc7f4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-245314dd-46fb-4798-b18d-0d27049cc7f4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-43cc37f6-ec17-45af-ae53-430905d88ec4' class='xr-var-data-in' type='checkbox'><label for='data-43cc37f6-ec17-45af-ae53-430905d88ec4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "    <tr>\n",
+       "        <td>\n",
+       "            <table style=\"border-collapse: collapse;\">\n",
+       "                <thead>\n",
+       "                    <tr>\n",
+       "                        <td> </td>\n",
+       "                        <th> Array </th>\n",
+       "                        <th> Chunk </th>\n",
+       "                    </tr>\n",
+       "                </thead>\n",
+       "                <tbody>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Bytes </th>\n",
+       "                        <td> 117.19 kiB </td>\n",
+       "                        <td> 39.06 kiB </td>\n",
+       "                    </tr>\n",
+       "                    \n",
+       "                    <tr>\n",
+       "                        <th> Shape </th>\n",
+       "                        <td> (3, 100, 100) </td>\n",
+       "                        <td> (1, 100, 100) </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Dask graph </th>\n",
+       "                        <td colspan=\"2\"> 3 chunks in 395 graph layers </td>\n",
+       "                    </tr>\n",
+       "                    <tr>\n",
+       "                        <th> Data type </th>\n",
+       "                        <td colspan=\"2\"> float32 numpy.ndarray </td>\n",
+       "                    </tr>\n",
+       "                </tbody>\n",
+       "            </table>\n",
+       "        </td>\n",
+       "        <td>\n",
+       "        <svg width=\"198\" height=\"188\" style=\"stroke:rgb(0,0,0);stroke-width:1\" >\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"10\" y1=\"120\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"10\" y2=\"120\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"16\" y2=\"126\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"22\" y2=\"132\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 28.46492855066211,18.46492855066211 28.46492855066211,138.4649285506621 10.0,120.0\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"130\" y2=\"0\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"16\" y1=\"6\" x2=\"136\" y2=\"6\" />\n",
+       "  <line x1=\"22\" y1=\"12\" x2=\"142\" y2=\"12\" />\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"10\" y1=\"0\" x2=\"28\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"130\" y1=\"0\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"10.0,0.0 130.0,0.0 148.4649285506621,18.46492855066211 28.46492855066211,18.46492855066211\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Horizontal lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"148\" y2=\"18\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"28\" y1=\"138\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Vertical lines -->\n",
+       "  <line x1=\"28\" y1=\"18\" x2=\"28\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "  <line x1=\"148\" y1=\"18\" x2=\"148\" y2=\"138\" style=\"stroke-width:2\" />\n",
+       "\n",
+       "  <!-- Colored Rectangle -->\n",
+       "  <polygon points=\"28.46492855066211,18.46492855066211 148.4649285506621,18.46492855066211 148.4649285506621,138.4649285506621 28.46492855066211,138.4649285506621\" style=\"fill:#ECB172A0;stroke-width:0\"/>\n",
+       "\n",
+       "  <!-- Text -->\n",
+       "  <text x=\"88.464929\" y=\"158.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" >100</text>\n",
+       "  <text x=\"168.464929\" y=\"78.464929\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(-90,168.464929,78.464929)\">100</text>\n",
+       "  <text x=\"9.232464\" y=\"149.232464\" font-size=\"1.0rem\" font-weight=\"100\" text-anchor=\"middle\" transform=\"rotate(45,9.232464,149.232464)\">3</text>\n",
+       "</svg>\n",
+       "        </td>\n",
+       "    </tr>\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-d81f968a-ad00-453f-aa6e-f1fcad17f83f' class='xr-section-summary-in' type='checkbox'  ><label for='section-d81f968a-ad00-453f-aa6e-f1fcad17f83f' class='xr-section-summary' >Indexes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-71c4d36d-447e-4321-8786-4151ab96624a' class='xr-index-data-in' type='checkbox'/><label for='index-71c4d36d-447e-4321-8786-4151ab96624a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([586145.0, 586155.0, 586165.0, 586175.0, 586185.0, 586195.0, 586205.0,\n",
+       "       586215.0, 586225.0, 586235.0, 586245.0, 586255.0, 586265.0, 586275.0,\n",
+       "       586285.0, 586295.0, 586305.0, 586315.0, 586325.0, 586335.0, 586345.0,\n",
+       "       586355.0, 586365.0, 586375.0, 586385.0, 586395.0, 586405.0, 586415.0,\n",
+       "       586425.0, 586435.0, 586445.0, 586455.0, 586465.0, 586475.0, 586485.0,\n",
+       "       586495.0, 586505.0, 586515.0, 586525.0, 586535.0, 586545.0, 586555.0,\n",
+       "       586565.0, 586575.0, 586585.0, 586595.0, 586605.0, 586615.0, 586625.0,\n",
+       "       586635.0, 586645.0, 586655.0, 586665.0, 586675.0, 586685.0, 586695.0,\n",
+       "       586705.0, 586715.0, 586725.0, 586735.0, 586745.0, 586755.0, 586765.0,\n",
+       "       586775.0, 586785.0, 586795.0, 586805.0, 586815.0, 586825.0, 586835.0,\n",
+       "       586845.0, 586855.0, 586865.0, 586875.0, 586885.0, 586895.0, 586905.0,\n",
+       "       586915.0, 586925.0, 586935.0, 586945.0, 586955.0, 586965.0, 586975.0,\n",
+       "       586985.0, 586995.0, 587005.0, 587015.0, 587025.0, 587035.0, 587045.0,\n",
+       "       587055.0, 587065.0, 587075.0, 587085.0, 587095.0, 587105.0, 587115.0,\n",
+       "       587125.0, 587135.0],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-edbcb35f-ef6a-49e6-823d-d4d1677b766d' class='xr-index-data-in' type='checkbox'/><label for='index-edbcb35f-ef6a-49e6-823d-d4d1677b766d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5906925.0, 5906915.0, 5906905.0, 5906895.0, 5906885.0, 5906875.0,\n",
+       "       5906865.0, 5906855.0, 5906845.0, 5906835.0, 5906825.0, 5906815.0,\n",
+       "       5906805.0, 5906795.0, 5906785.0, 5906775.0, 5906765.0, 5906755.0,\n",
+       "       5906745.0, 5906735.0, 5906725.0, 5906715.0, 5906705.0, 5906695.0,\n",
+       "       5906685.0, 5906675.0, 5906665.0, 5906655.0, 5906645.0, 5906635.0,\n",
+       "       5906625.0, 5906615.0, 5906605.0, 5906595.0, 5906585.0, 5906575.0,\n",
+       "       5906565.0, 5906555.0, 5906545.0, 5906535.0, 5906525.0, 5906515.0,\n",
+       "       5906505.0, 5906495.0, 5906485.0, 5906475.0, 5906465.0, 5906455.0,\n",
+       "       5906445.0, 5906435.0, 5906425.0, 5906415.0, 5906405.0, 5906395.0,\n",
+       "       5906385.0, 5906375.0, 5906365.0, 5906355.0, 5906345.0, 5906335.0,\n",
+       "       5906325.0, 5906315.0, 5906305.0, 5906295.0, 5906285.0, 5906275.0,\n",
+       "       5906265.0, 5906255.0, 5906245.0, 5906235.0, 5906225.0, 5906215.0,\n",
+       "       5906205.0, 5906195.0, 5906185.0, 5906175.0, 5906165.0, 5906155.0,\n",
+       "       5906145.0, 5906135.0, 5906125.0, 5906115.0, 5906105.0, 5906095.0,\n",
+       "       5906085.0, 5906075.0, 5906065.0, 5906055.0, 5906045.0, 5906035.0,\n",
+       "       5906025.0, 5906015.0, 5906005.0, 5905995.0, 5905985.0, 5905975.0,\n",
+       "       5905965.0, 5905955.0, 5905945.0, 5905935.0],\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>time</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-f78e1e8f-6418-43b3-8051-56698771c73e' class='xr-index-data-in' type='checkbox'/><label for='index-f78e1e8f-6418-43b3-8051-56698771c73e' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2020-07-18 10:25:59.024000&#x27;, &#x27;2020-07-23 10:30:31.024000&#x27;,\n",
+       "               &#x27;2020-07-28 10:25:59.024000&#x27;],\n",
+       "              dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;time&#x27;, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a400af5c-45a5-4818-81cd-a1aebef44a94' class='xr-section-summary-in' type='checkbox'  ><label for='section-a400af5c-45a5-4818-81cd-a1aebef44a94' class='xr-section-summary' >Attributes: <span>(4)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>stac_item_id :</span></dt><dd>S2B_MSIL2A_20200718T102559_N0500_R108_T32UNE_20230425T043013</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd><dt><span>stac_item_ids :</span></dt><dd>{&#x27;2020-07-18T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200718T102559_N0500_R108_T32UNE_20230425T043013&#x27;], &#x27;2020-07-23T10:30:31.024000&#x27;: [&#x27;S2A_MSIL2A_20200723T103031_N0500_R108_T32UNE_20230504T135307&#x27;], &#x27;2020-07-28T10:25:59.024000&#x27;: [&#x27;S2B_MSIL2A_20200728T102559_N0500_R108_T32UNE_20230505T111819&#x27;]}</dd></dl></div></li></ul></div></div>"
+      ],
+      "text/plain": [
+       "<xarray.Dataset> Size: 482kB\n",
+       "Dimensions:      (time: 3, y: 100, x: 100)\n",
+       "Coordinates:\n",
+       "  * x            (x) float64 800B 5.861e+05 5.862e+05 ... 5.871e+05 5.871e+05\n",
+       "  * y            (y) float64 800B 5.907e+06 5.907e+06 ... 5.906e+06 5.906e+06\n",
+       "    spatial_ref  int64 8B 0\n",
+       "  * time         (time) datetime64[ns] 24B 2020-07-18T10:25:59.024000 ... 202...\n",
+       "Data variables:\n",
+       "    B02          (time, y, x) float32 120kB dask.array<chunksize=(1, 100, 100), meta=np.ndarray>\n",
+       "    B03          (time, y, x) float32 120kB dask.array<chunksize=(1, 100, 100), meta=np.ndarray>\n",
+       "    B04          (time, y, x) float32 120kB dask.array<chunksize=(1, 100, 100), meta=np.ndarray>\n",
+       "    SCL          (time, y, x) float32 120kB dask.array<chunksize=(1, 100, 100), meta=np.ndarray>\n",
+       "Attributes: (4)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ds = store.open_data(\n",
+    "    data_id=\"sentinel-2-l2a\",\n",
+    "    point=(10.3, 53.3),\n",
+    "    bbox_width=1000, \n",
+    "    time_range=[\"2020-07-15\", \"2020-08-01\"],\n",
+    "    spatial_res=10,\n",
+    "    asset_names=[\"B02\", \"B03\", \"B04\", \"SCL\"],\n",
+    ")\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 264 ms, sys: 37.9 ms, total: 302 ms\n",
+      "Wall time: 6.55 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.collections.QuadMesh at 0x73654cb3ad50>"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkkAAAHUCAYAAAAukLw0AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjUsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvWftoOwAAAAlwSFlzAAAPYQAAD2EBqD+naQAA7aBJREFUeJzsnXl4FEX6x79zT+4QjoRwBARELgFBOVwFl8NlPWG9DzzwBBVEVhfRFVFhRUVURERORY51lZ+ui0pAQREQF0UFFVG5xIRwhNyZycz07w82w9S3ku5MDoLyfp4nz5Pqrq6qrq7uVOr91vvaDMMwIAiCIAiCICjY67sBgiAIgiAIJyIySRIEQRAEQagAmSQJgiAIgiBUgEySBEEQBEEQKkAmSYIgCIIgCBUgkyRBEARBEIQKkEmSIAiCIAhCBcgkSRAEQRAEoQJkkiQIgiAIglABMkmyYObMmViwYIF2fNeuXbDZbBWes6Im19aU1atXo2fPnoiLi4PNZsP//d//Hbe6ly5dim7dusHr9SI9PR1jxoxBYWFhtcuri2fzW+Ctt97C1VdfjbZt2yImJgatWrXCtddeix07dlSYf9WqVejTpw9iY2PRqFEj3HjjjcjJyVHybN68GaNGjUKXLl2QkJCA1NRUDBw4EB9++GGFZf78888YNmwYkpOTER8fj0GDBuGLL76I6j6q0q6JEyfCZrNV+rN06VLLen755ReMGTMG/fr1Q3JysunY8Pl8eOqpp9C5c2fExcUhNTUVQ4YMwfr168N5WrVqZdqm8p/yOl599VVcddVVaN++Pex2O1q1alVpWwsLCzFmzBikp6fD6/WiW7duVbpHAMjKysJDDz2EPn36oFGjRkhMTESPHj0we/ZsBINBJe+aNWsqbffGjRurVF9l/XDHHXdoeTdt2oTzzz8fCQkJiI+Px3nnnYdPP/20SvUAQE5ODm688UY0atQIsbGx6NOnD1avXq3kyc/PxxNPPIH+/fsjLS0N8fHx6NKlC5588kmUlpaalr9q1apw+w8ePKidj2a8V/U7V5NnLRxHDMGUTp06Gf369dOOl5aWGhs2bDBycnKiLnPnzp0GAGP+/Pk1b2AUhEIhIyUlxejdu7exatUqY8OGDcbhw4ePS92LFi0yABi33HKL8eGHHxqzZs0ykpKSjEGDBlW7zLp4Nr8FzjrrLOPiiy825s2bZ6xZs8Z47bXXjA4dOhjx8fHG1q1blbxr1qwxnE6ncckllxgrV640Fi1aZDRr1szo3LmzUVpaGs533333GT179jSmTZtmrF692njnnXeMP//5zwYAY+HChUqZOTk5Rnp6utGpUyfjzTffNP7zn/8Yf/jDH4yEhATj+++/r9I9VLVde/fuNTZs2KD9dO7c2YiJiTFyc3Mt6/roo4+MRo0aGQMHDjSuvvpq03fv+uuvN+x2uzFhwgRj9erVxhtvvGH06NHDcDqdxmeffWYYhmF88cUXSltGjBhhADDef/995Xj5+Bs4cKDRuXNn47rrrjPatm1rZGRkVNrWQYMGGcnJycasWbOMDz/80LjlllsMAMbrr79ueZ///ve/jRYtWhgTJkww/vOf/xgrV6407r33XsNutxs33XST1icAjMmTJ2t9W1BQYFmXYRhGRkaGcfbZZ2vX//zzz0q+TZs2GR6PxzjnnHOM5cuXG2+99ZbRu3dvw+PxGOvXr7esp7S01OjcubPRvHlzY9GiRcbKlSuNSy65xHA6ncaaNWvC+b755hujUaNGxr333mu8/fbbxurVq42JEycaXq/XGDBggBEKhSosv6CgwGjVqpWRnp5uADAOHDignI9mvEfznavJsxaOHzJJsqCyP8Q1obYmSYFAQPmDYsUvv/xiADCefPLJGtUbLYFAwGjatKkxePBg5fjrr79uADBWrFhRrXLr4tn8Fti/f792bN++fYbL5TJGjBihHD/zzDONjh07GmVlZeFjn376qQHAmDlzpmmZgUDAOP300402bdoox//6178aLpfL2LVrV/hYXl6e0ahRI+OKK66o0j1UtV0VsXPnTsNmsxnXXXddleoKBoPh3z///PNK373S0lLD4XBo5f76668GAOOee+6psPxHHnmkwj+uFdV/wQUXVDpJ+s9//mMAMBYvXqwcHzRokJGenm4EAoEKryvn8OHDht/v146PGjXKAGDs2bMnfKx8kvTGG2+YlmlGRkaGccEFF1jmO//8843U1FSjqKgofCw/P99o1KiR0bdvX8vrX3zxRQOAMqEqKyszOnbsaJx11lnhY4WFhUZhYaF2/VNPPWUAMD755JMKyx81apTRvXt346GHHqrwOVZ1vEfznavpsxaOH78Zc9uBAwdw2223oUWLFvB4PGjcuDHOPvtsrFq1Kpynf//+6Ny5Mz755BP07t0bMTExaNasGR5++GFtufnRRx9Fr169kJKSgsTERJxxxhmYO3cujIh4v61atcK2bduwdu3a8FJs+VJ5RSadH3/8ETfddBPatWuH2NhYNGvWDBdddBG++eabGt9/eX1Tp07F448/jtatW8Pj8eCjjz4CAPz3v//FxRdfjJSUFHi9XnTv3h3//Oc/w9dPnDgRzZs3BwA88MADyr3UNRs3bkRWVhZuuukm5fjll1+O+Ph4LF++POoyo3025Wabr7/+GpdffjmSkpKQkpKCsWPHIhAIYPv27fjTn/6EhIQEtGrVClOnTtXqzM/Px7hx49C6dWu43W40a9YMY8aMQVFRUdTtrwlNmjTRjqWnp6N58+bYu3dv+Ni+ffvw+eef4/rrr4fT6Qwf79u3L0499VSl3ysq0+FwoEePHkqZALB8+XL88Y9/REZGRvhYYmIihg0bhn//+98IBAKm7Y+mXRUxb948GIaBW265xTRfOXZ71T5zdrsddrsdSUlJyvHExETY7XZ4vd4qlVPd+pcvX474+HhcfvnlyvGbbroJv/76Kz777DPT6xs0aACXy6UdP+usswAcNTvWB59++in69++P2NjY8LGEhASce+65WL9+PbKyskyvX758Odq3b48+ffqEjzmdTlx33XXYtGkT9u3bBwCIi4tDXFycdn35/fM4BoBPPvkEs2fPxpw5c+BwOCqtvyrjPZrvXE2ftXD8+M1Mkq6//nr83//9H/7+979j5cqVmDNnDgYOHIhDhw4p+bKzs3HVVVfh2muvxdtvv43LLrsMjz/+OEaPHq3k27VrF26//Xb885//xFtvvYVhw4bh7rvvxmOPPRbOs3z5cpxyyino3r07NmzYgA0bNph+wH/99Vc0bNgQ//jHP/D+++/jxRdfhNPpRK9evbB9+/Za6Yfnn38eH374IZ5++mm89957OO200/DRRx/h7LPPxpEjRzBr1iy8/fbb6NatG6688srwROGWW27BW2+9BQC4++67Le8FAAKBQJV+IieWFbF161YAwOmnn64cd7lcOO2008LnoyHaZ1POFVdcga5du+LNN9/ErbfeimeffRb33nsvLr30UlxwwQXhD+IDDzwQ7i8AKC4uRr9+/bBw4ULcc889eO+99/DAAw9gwYIFuPjiiy37IBQKVakveTJfVX7++Wfs3r0bnTp1Ch+rrN/Lj1n1eyAQwCeffKKUWVJSgp9++qnSMktKSvDzzz+blluTdoVCISxYsABt27ZFv379TOuJFpfLhZEjR2LhwoX4v//7P+Tn52PXrl249dZbkZSUhFtvvbVW62O2bt2KDh06KBNH4Fg/RfbLggULqqy7+/DDD+F0OnHqqadq50aNGgWn04nExEScf/75WLdunZbHrK6PP/4YCQkJcLlc6NixI5555hltDPv9fng8Hu3a8mNW/0Ru3bq10rECANu2bTO9vlxXFzmOgaNjecSIERgzZgzOOOOMCq+NZrxH852L5lkL9YvTOsuJwaeffopbbrlF+VBdcsklWr5Dhw7h7bffxsUXXwwAGDx4MEpKSvDSSy/h/vvvR8uWLQEA8+fPD18TCoXQv39/GIaB5557Dg8//DBsNhu6d++OmJgYJCYmonfv3pZtPPfcc3HuueeG08FgEBdccAE6deqEl19+GdOmTav2/Zfj9XrxwQcfKP8xDhkyBJ06dQp/DAHg/PPPx8GDB/Hggw9i+PDhaN68efg/npYtW1bpfir6r7Qi5s+fjxtvvLHS8+UT2ZSUFO1cSkoKdu3aVaV6Ion22ZRz2223YezYsQCAgQMHYuXKlZgxYwbeeustDB06FMDRFcl3330Xr7/+OoYNGwbg6OT066+/xmeffYaePXsCAAYMGIBmzZrhsssuw/vvv48hQ4ZUWu+kSZPw6KOPWrYvIyMj6v4IBAIYMWIE4uPjce+994aPW/U7/4PBTJw4ET/++KMi7s/NzYVhGJWWGVlvZdSkXStXrsTevXsxZcoU0zqqy7PPPoukpCT85S9/QSgUAnD0ffnwww/Rtm3bOqmznEOHDuGUU07RjlfUr3a7HQ6Hw3KVauXKlXjttdcwevRoNGzYMHw8KSkJo0ePRv/+/dGwYUP8+OOPeOqpp9C/f3/85z//wfnnn29Z1wUXXICePXuiTZs2yM3NxRtvvIFx48Zhy5YteO2118L5OnbsiI0bNyIUCoXLCAQC4dWSqoyX6o63r7/+GlOnTsXQoUO1yUu5hcHsvYxmvEfznYvmWQv1y29mknTWWWdhwYIFaNiwIQYOHIgePXpU+Ec8ISEhPEEq55prrsErr7yCjz/+GNdddx2Ao/9dTJ48GZ9//jny8/OV/Dk5OUhNTY26jYFAAFOnTsWiRYvw448/oqysLHzuu+++i7q8irj44ouV+/7xxx/x/fff4+mnnw63oZw///nPePfdd7F9+3Z06NAh6ro+//zzKuVr3bp1lfLZbLaojtcFF154oZLu0KEDvvrqK2WC43Q60bZtW+zevTt87N1330Xnzp3RrVs3pY/PP/982Gw2rFmzxnSSdNttt2l1V0RF/3GbYRgGRowYgU8++QRvvvkmWrRooeWpTr/PmTMHTzzxBO67774K/xkxu7b8XDAYVFbYys1ZNWnX3Llz4XQ6tUm5YRjaCgb/l14VnnjiCTz99NOYOHEizjnnHOTn52PGjBkYNGgQVq5cie7du0ddZjRUpV8BYPjw4Rg+fLhpWV988QWuuOIK9O7dW5tUdu/eXbmXc845B0OHDkWXLl1w//33K5Okyup68cUXlfQll1yCBg0aYMaMGRg7dmy4/LvvvhsjRozAXXfdhQkTJiAUCuHRRx8Nv19VMUdWtV8i2bVrFy688EK0aNECc+bMUc5t2rQJ06dPx/vvv4+YmJharb+q47o69yQcf34zk6Rly5bh8ccfx5w5c/Dwww8jPj4eQ4cOxdSpU5GWlhbOV9Hkpvx8+ex806ZNGDx4MPr3749XXnkFzZs3h9vtxv/93//hiSeeQElJSbXaOHbsWLz44ot44IEH0K9fPzRo0AB2ux233HJLtctkmjZtqqT3798PABg3bhzGjRtX4TUVbWmtCt26datSvsps+eWU/wd76NAh7fkcPny4wv+86gquy+12IzY2VtObuN1uZfK8f/9+/Pjjj5Wurln1cVpaWoW6Hyaaj2O5LmfRokVYuHChNpmJ7HfGrN/nz5+P22+/Hbfddhueeuop5VyDBg1gs9kqLRM41scDBgzA2rVrw+dvuOGG8D861WnXwYMH8c477+CCCy5Q3nkAWLhwoaYFsTKBMt999x3+/ve/Y+rUqcq7NGTIEHTs2BFjx44NawDrgoYNG1apX6vCl19+iUGDBqFdu3ZYsWJFlSbfycnJuPDCCzFr1iyUlJRUafLAXHfddZgxYwY2btwYniTdfPPNOHDgAB5//HG89NJLAIA+ffpg3LhxePLJJ9GsWTPTMqvTL7t378Z5550Hp9OJ1atXa3luvvlmDBs2DD179sSRI0cAIOwmID8/Hx6PBwkJCVGN92i+c7X5rIW65TczSWrUqBGmT5+O6dOnY8+ePXjnnXfwt7/9DTk5OXj//ffD+conDZFkZ2cDODaIly5dCpfLhXfffVf541hTn0GLFi3C8OHDMXnyZOX4wYMHkZycXKOyy+E/oo0aNQIAjB8/PmwaYtq3b1+tumrL3NalSxcAR7UHHTt2DB8PBAL4/vvvcfXVV1erfceTRo0aISYmBvPmzav0vBm1bW4rnyDNnz8fc+fODa+QRtK5c2cAR/v9z3/+s3Lum2++CZ+PZP78+bjllltwww03YNasWdp4i4mJQdu2bSvUkXzzzTeIiYkJmxFefvllFBQUhM+X91F12gUAr732Gvx+f4WC7YsuuqjKK5+V8dVXX8EwDJx55pnKcZfLha5duyoTvrqgS5cuWLJkCQKBgLIKVt7XlfUL8+WXX2LgwIHIyMjAypUrNSG6GeUTy+quZJRfz6tDDzzwAMaMGYMdO3YgISEBGRkZuP322xEXF4cePXqYltmlS5dKxxug98vu3bvD8ok1a9aEN6xEsm3bNmzbtg1vvPGGdq5Nmzbo2rUrtmzZEtV4j+Y7V1vPWqh7fjOTpEhatmyJu+66C6tXr9YckhUUFOCdd95RTG6LFy+G3W4P64VsNhucTqeyAlJSUqLY0cvxeDxVXgWy2Wzaf2z/+c9/sG/fvjrTM7Rv3x7t2rXDV199pU3Oakptmdt69eqFpk2bYsGCBbjyyivDx//1r3+hsLCw0smdFdE8m5py4YUXYvLkyWjYsGGVzYuR1Ka5zTAM3HrrrZg/fz5efvllbQWlnGbNmuGss87CokWLMG7cuPB437hxI7Zv344xY8Yo+RcsWIBbbrkF1113HebMmVPpH8qhQ4di+vTp2Lt3b9i8V1BQgLfeegsXX3xx+KNf2eQ82naVM3fuXKSnp1do1mzYsKGiuakO6enp4XZEisJ9Ph+++OKLCv/Y1iZDhw7FK6+8gjfffFN5TxYuXIj09HT06tXLsowtW7Zg4MCBaN68OTIzM9GgQYMq15+bm4t333037AixOrz66qsAUKFO0OPxhP/479mzB8uWLcOtt95quWI1dOhQjBw5Ep999lm4DwKBABYtWoRevXqFn1t5uf3790cwGMSaNWuUHWmRVLQiuGDBgrBoP3J1q6rjPZrvXG08a+E4cbx9DlSHI0eOGN27dzeeeuop49///rexZs0a46mnnjK8Xq9xzTXXhPP169fPaNiwoZGenm688MILxgcffGCMHj3aAGDceeed4XyrV682ABiXXXaZsXLlSmPJkiVGjx49jHbt2hkAjJ07d4bz3nDDDYbH4zGWLl1qbNq0yfj6668Nw6jY19Hw4cMNj8djPPvss8bq1auNqVOnGo0bNzaaN2+u+POpjp+k8mueeuop7dyHH35oeDweY/DgwcbixYuNtWvXGsuXLzcmT55sXHbZZVUqo6557bXXDADGbbfdZnz00UfG7NmzjeTk5AqdrAGokv+jaJ5NZb5sbrjhBiMuLk4ru1+/fkanTp3C6cLCQqN79+5G8+bNjWeeecbIzMw0PvjgA+OVV14xLr/8cmPjxo1V7Imac9dddxkAjJtvvllz5PfFF18oeT/66CPD6XQaQ4cONTIzM43XX3/daNGihea08Z///Kdht9uNM844w/j000+1ciPz5uTkGE2bNjW6dOliLF++3FixYoVx7rnnGgkJCcZ3331XpXuoarvK2bhxowHAePDBB6vVZ2+88YbxxhtvGE8++aQBwBg1alT4WDnBYNA488wzDa/Xa/z97383Vq1aZbz55ptG//79DQDGa6+9VmHZVn6Stm3bFq6rR48eRuPGjcPpbdu2KXkHDRpkNGjQwJg9e7bx4YcfGrfeeqsBwFi0aJGSb+HChYbD4VAcfX7//fdGw4YNjZSUFOPf//639gwjnateffXVxgMPPGC88cYb4fexffv2htPpNDIzMy3rev31142//OUvxrx584zVq1cbb775pnHVVVcZAIwbb7xRuf6bb74xJk6caLz77rtGZmam8fTTTxuNGjUyevbsqTmuvPnmmw2Hw6H4JCotLTU6depktGjRwnj99deNzMxMY+jQoZozyf379xunnHKK4fF4jEWLFmn3v3fv3gqfTzmVPcdoxns037mqPmuhfvlNTJJKS0uNO+64wzj99NONxMREIyYmxmjfvr3xyCOPKA7Kyv+wrVmzxujZs6fh8XiMpk2bGg8++KDitM4wDGPevHlG+/btDY/HY5xyyinGlClTjLlz52qTpF27dhmDBw82EhISDABhR3AV/SHOzc01RowYYTRp0sSIjY01/vCHPxiffPKJ0a9fvzqdJBmGYXz11VfGFVdcYTRp0sRwuVxGWlqa8cc//tGYNWtWlcuoaxYvXmycfvrphtvtNtLS0ox77rlH+0gWFBQYAIyrrrrKsrxonk1NJ0mGcXSi9NBDDxnt27c33G63kZSUZHTp0sW49957jezs7Cr2Qs3JyMgwAFT4U5GjwpUrVxq9e/c2vF6vkZKSYgwfPlxzHnnDDTdUWia/E4ZhGD/++KNx6aWXGomJiUZsbKwxYMAAY/PmzVHdR1XaVc6tt95q2Gw246effoqqjnLM7i2SI0eOGBMmTDA6dOhgxMbGGk2aNDH69+9v6vDUapJUfr6in0ceeUTJW1BQYNxzzz1GWlqa4Xa7jdNPP91YsmSJVub8+fO1MV5+rLKfyLxTpkwxunXrZiQlJRkOh8No3LixMXToUGPTpk1VqmvDhg3GgAEDjLS0NMPlchmxsbHGmWeeacycOVNxnmkYhrF9+3bj3HPPNVJSUgy32220bdvWeOihhyp0/Fg+Dnm8ZWdnG8OHDzdSUlIMr9dr9O7dW5vMlTvIrGpfM2bPMZrxXpXvnGFU/VkL9YvNMKJUN57A9O/fHwcPHhQfE79hVqxYgQsvvBBfffVV2MYvCIIgCPXBb8aZpHBy8NFHH+Gqq66SCZIgCIJQ7/wmhdu/N6zCOLB/md8zvOVcEARBEOqL39Vf3jVr1vzmTG27du2Cy+Uy/Zk0aVJ9N1MQBEEQTjpkJameSU9Pt9xqH7nFVRAEQRCE48PvSrgtCIIgCIJQW/yuzG2CIAiCIAi1hUySBEEQBEEQKkAmSYIgCIIgCBUgk6Rq0r9/f9hsNuXnqquuMr2moKAAY8aMQUZGBmJiYtC3b19NtG0YBiZOnIj09HTExMSgf//+2LZtm1bWhg0b8Mc//hFxcXFITk5G//79o45jduTIEYwaNQpNmzaF1+tFhw4dsGLFiqjKEARBEITfKzJJMqF///5YsGBBpedvvfVWZGVlhX9efvll0/JuueUWZGZm4rXXXsM333yDwYMHY+DAgdi3b184z9SpUzFt2jTMmDEDn3/+OdLS0jBo0CAlmvqGDRvwpz/9CYMHD8amTZvw+eef46677orKl5Lf78egQYOwa9cu/Otf/8L27dvxyiuvKIEdBUEQBOGkpl6Dopzg9OvXr9L4av369TNGjx5d5bKKi4sNh8NhvPvuu8rxrl27GhMmTDAMwzBCoZCRlpZm/OMf/wifLy0tNZKSkpQYbL169TIeeugh0/p++eUX44orrjCSk5ONlJQU4+KLL1biIb300kvGKaecYvj9/irfgyAIgiCcTMhKUg14/fXX0ahRI3Tq1Anjxo1TVnuYQCCAYDAIr9erHI+JicG6desAADt37kR2djYGDx4cPu/xeNCvXz+sX78eAJCTk4PPPvsMTZo0Qd++fZGamop+/fqFywCA4uJinHfeeYiPj8fHH3+MdevWIT4+Hn/605/g9/sBAO+88w769OmDUaNGITU1FZ07d8bkyZMRDAZrrX8EQRAE4beMOJOsJtdeey1at26NtLQ0bN26FePHj8dXX32FzMzMCvMnJCSgT58+eOyxx9ChQwekpqZiyZIl+Oyzz9CuXTsAQHZ2NgAgNTVVuTY1NRW7d+8GAPz8888AgIkTJ+Lpp59Gt27d8Oqrr2LAgAHYunUr2rVrh6VLl8Jut2POnDmw2WwAgPnz5yM5ORlr1qzB4MGD8fPPP+PDDz/EtddeixUrVmDHjh0YNWoUAoEA/v73v9dJnwmCIAjCbwmZJEUwefJkTJ48OZwuKSnBxo0bcdddd4WPvffeezjnnHNw6623ho917twZ7dq1Q8+ePfHFF1/gjDPOqLD81157DTfffDOaNWsGh8OBM844A9dccw2++OILJV/5xKYcwzDCx0KhEADg9ttvx0033QQA6N69O1avXo158+ZhypQp2Lx5M3788UckJCQo5ZSWluKnn34Kl9OkSRPMnj0bDocDPXr0wK+//oqnnnpKJkmCIAiCAJkkKdxxxx244oorwulrr70Wf/nLXzBs2LDwscqEzWeccQZcLhd27NhR6SSpTZs2WLt2LYqKipCfn4+mTZviyiuvROvWrQEAaWlpAI6uKDVt2jR8XU5OTnh1qfx4x44dlbI7dOiAPXv2ADg6AerRowdef/11rQ2NGzcOl+NyueBwOJQysrOz4ff74Xa7K7wHQRAEQThZkElSBCkpKUhJSQmnY2Ji0KRJE7Rt29by2m3btqGsrEyZ3FRGXFwc4uLikJubiw8++ABTp04FgLD5LjMzE927dwdwdBfa2rVr8eSTTwIAWrVqhfT0dGzfvl0p84cffsCQIUMAHJ2wLVu2DE2aNEFiYmKFbTj77LOxePFihEKh8K64H374AU2bNpUJkiAIgiBAXABUi59++gmTJk3Cf//7X+zatQsrVqzA5Zdfju7du+Pss88O5xswYABmzJgRTn/wwQd4//33sXPnTmRmZuK8885D+/btw2Yzm82GMWPGYPLkyVi+fDm2bt2KG2+8EbGxsbjmmmvCef7617/i+eefx7/+9S/8+OOPePjhh/H9999jxIgRAI6ugDVq1AiXXHIJPvnkE+zcuRNr167F6NGj8csvvwAA7rzzThw6dAijR4/GDz/8gP/85z+YPHkyRo0adby6URAEQRBOaGQlqRq43W6sXr0azz33HAoLC9GiRQtccMEFeOSRRxTz1U8//YSDBw+G03l5eRg/fjx++eUXpKSk4C9/+QueeOIJuFyucJ77778fJSUlGDlyJHJzc9GrVy+sXLlS0ReNGTMGpaWluPfee3H48GF07doVmZmZaNOmDQAgNjYWH3/8MR544AEMGzYMBQUFaNasGQYMGBBeWWrRogVWrlyJe++9F6effjqaNWuG0aNH44EHHqjr7hMEQRCE3wQ2wzCM+m6EIAiCIAjCiYaY2wRBEARBECpAJkmCIAiCIAgVIJokHN0y/+uvvyIhIUHzUSQIgiAIkRiGgYKCAqSnp0cVM7O2Kde3xsbG1lsbfu/IJAnAr7/+ihYtWtR3MwRBEITfEHv37kXz5s3rpe49e/agXbtWuP36JDw/J7de2nAyIMJtHN11lpycjN7n/A1O59HYaqUp6vyxKI3+W6Be8+SrB+wB9XxJI/KiTQtW8VkhJR1zsExJ28rU80GvQ0k7/MfO2/1qXoTMH7HhVBsTcjkqyXmU3PYeJZ3XQY335jqsXm+41fptPrU+O4WL474L0VTel6pekNLiiJLu1nCfkm4bl6OkmzjzlHSZoVaQXZakpIMU4jBgqPf3Q6EaRmZfoeqbKtblV9K9Gu5W0qd41fY1sBcp6YJQjJLOzD3mSPTnvIbKuQM/NFbSNnUYwX1E7fvYHPXZhBzq+aAaahD5bdW+Tz3lkJL2OtUKU2MLlfQvhWrf/rqjiZKOb67GPzytkdo3zKFStW+4vi9+VZ2/Or5UvdD7U9T7D8ar92ePV+/HCNF7nO+CekA9b6NXEfTeGy61fkeiOlZsdrUAZaHbrl5bVqT6N3PFqWW5nGpZxfvjlLTdp45zzwG1sY22qi+ms0hN2+g7Y9i5L6L7U2MLcnl0nvuWoT9ttqB6gUErQPZS9X4Ml3o+5Dn23gcCPnz6+VM4cuQIkpLUMX28uPmaJPzwox+bv/Hh++93IiMjo17a8XtHVpJwLAyI0+kNT5KcLrVrHB7zSZKDJgK8AuvwmE+SnC71BXY61T/ENoM+lnTeEYqYJIVqOElymk+SHG51kmSPUf+wOGgCF+K+sVlMkugPu43+Dmn1xartccerfyy8ceqzjHGqaSdNkrxlaoU8SSqjSZLLUOtzGmp7nC71fj3xavkxXrX+WIdafjCkpt3+Y/U5A/QsKICyjR4lj0MetzaaJEEtXut7Zxzdq1PtK1es+oea+8Yeo7bXQfldceaOTZ0OtTyuzxFL5XvUtN1Lf4jp/uyxNOEP0ntcVruTJHus2n9mkyQbTZKCIbWvHFSWw0n3Rn1vt1F+GitOF02SnHU8SbLV8iTJZjFJctCEmN7Dir6L9SXP2L59Oxa/VYCvP2qJR58+jIl/Ox3zl+RZXyhEjQi3BUEQBOE3xMP398QNVySgbWs3Jv41BUuWF+D777+v72b9LpGVpAhKGzrDK0ieXPqPuUT9L6Qsnv/LUMvyJdHqwRH1v5q4LPW/MHuZudnDEaB0Ka2m+I6lDQf/y6UmeRWM0f4jdJr/d8zL9MEY9XpnEf1HqlqTtPJ8KWq6LN2npFMaqSaVVkmqPT7ZVQwzPs1vp6SzStTlcj+t3JQG1Idr0GpBHJnTTmuwX0knOkuVdJJTbd/hQLySXnVYjcu37VCamn93cvj31u2zlHOhBmpb+NnbDqgrL9z3tNCDUtWaB3dqiZKOd6vPJpHScU61PdmHVVOks1AdO74yta8PlpoLUovL1NWTdVvVZxu7W13poUVALW0vplU8B61GOOnl4XQZdzjVR6s/jiS1fxIS1P4tLOKVumPvOa+0BNz0TaBVqOI9qqkxNotWUsjMHXOA2krfHO3e+NYtVo6szGnRrhwZ9M20+9T22sqo/fTsQ7HqWIk0rwGAEbFqFOIl2uPIF198gXdXFmH7+lYAgDat3LjxykQ89Ncz8a9/F5hfLESNrCQJgiAIwm+ECX89B3femIRmTY/9QzFhTApWrCrC5s2b67Flv09kkiQIgiAIvwE++eQTfLqpFA/cpS63N2vqxKibk/HguHPrqWW/X2SSJAiCIAgnOIZh4MFxgzH2jmQ0aqib++4f1QAbN5di7dq19dC63y+iSYrAn2BH0H103ug9pBroAzHqoCxqQjobVYqBhH2q/dt9hLaXss6H7PO8jV/b1k9oOqTIsi20ASHeike7QoLkEsBdQPopr9o290E1P2uQaDMZilNpZ1+aqstI8Ki7TtwOtW8Plai6ldJAUyWd5VE1R/ll6q4er0N9Nqle1a7vpO13rDFq6VG3we/xqUKerFK1/szd7ZV00UF1K7Y3S+0gO8mMHA2O9X+bRLXu/Ymq7qSMND6uYlXjwto32iyHskT1WTdPzlfSTtK9JLrUZxckoUrgEO02o91d8TH0IhHJHrXvgyF17LoPqLoS9xH1eno0GgZrkEpZtMTbWqP0oEIaJjeNbS/tGCuk7YWReriQwbvP1HFakq/2dfwe6iuSr7DmJ+Yw7YajbxBrgBj+pjGsOQLvFLPyTsO71wKUX9tZSDsT3eqzLYunD5Ot8m806xKPB++99x6+/7EM777eoMLzDVMcuO+OZDz41z9h3WfF4hi5lpCVJEEQBEE4gQmFQpjwwDD87e4GSIiv/M/26Nsa4IefyrBixYrj2LrfNzJJEgRBEIQTmH/96184cCiIO24wd1yZEG/H+HsaYMIDwxBif3lCtRBzWwQNvi+G839eaQ1yiudLIid5ZEKK5y39vDTN5jVaGrYHyGkcp60GfMTyLztx07KykzfD/Lydls1D7D+PPPnay2gZW7UAwZ9O3sRp6zJTVKiaHApyVfNabJJq4mnTUDVBdUlQPXDbya7gJbfUBSHVTHGIbuCnQtWr9Yrd6pb9gt3qh8y7Xx07bH4kjwaaiwY/9V+w27ECCsh06CBzUFGBukWeHEqD/A8iSDvugwnquI4hj9oFfvXZnJqgmsN+LmykpF1HaGwkqw1qHKd2ho/cLwTIvHagUHWf4D0IU4J0v5p5jfreRlv62VSsGYSo/zWLkZtM0+Sgkd1NMJHFlZVG9/kOqFZd2Cw83TtK2T8E3Rs5n7RRb2hb+Nn8ZjM381tt+ecoBDa6PuRR+yfkIFceFt/BELc/MvtxtGQFAgE8/OB1eHhsCmJirNc17rghCc/OPoJ//vOfuOqqq45DC3/fyEqSIAiCIJygzH++GUIh4MYrE60zA/B67Xh4bAoefnA4ysrKrC8QTJFJkiAIgiCcgJSWlmLSM4fx6P0N4XJVffnqxisTYbMB856rn+C7vydkkiQIgiAIJyAvTW2BlGQ7rrg43jpzBE6nDY/e3xCPTTuM0tJS6wsqYObMmWjdujW8Xi969OiBTz75pNK8b731FgYNGoTGjRsjMTERffr0wQcffKDle/PNN9GxY0d4PB507NgRy5cvr1G9xwPRJEUQ8jiOBTHk7bAHaUt/vrmOxp+kdq3niLrs6SymYIqsI2ItA9vn2ZyvRL4kHUW0U2GLMCZaAFq/WkFpY9IoUUgVDhKKAAWQLTNvsDte3RMf71XTLeLUMCUHy9QPjI9iyHybp4b9+Hm/qqPBL2qkec8hDjmjZk8hbQeT21ntn8AB9X5Lmqpjq1PnPZWWtWmzGoaD3TG4Dqn3yjoP1jtx2hGj3syBIrUvPbRl3UUuAX46pO6557GDePX6WNI8sXsGDhlTlKc+G2o+AupphMjlgI3HIuvzaMs+py2h7K449f5i3Wo6v0TVmBkkjDEi3HmwpEcLhkvnA6Q3Y22cK8/cDQm7GWHXIpqeK0rdMOe3+TmMCAXijiGNkRY8OMoPH3/nWDcaoYFiDWldUFBQgCnP52LOs01gt9CZVsTlF8Vj6oxczHyyBcY+ciCqa5ctW4YxY8Zg5syZOPvss/Hyyy9jyJAh+Pbbb9GyZUst/8cff4xBgwZh8uTJSE5Oxvz583HRRRfhs88+Q/fu3QEAGzZswJVXXonHHnsMQ4cOxfLly3HFFVdg3bp16NWrV7XqPR7ISpIgCIIgnGA8+1grtDvFhQsGxllnrgC73YbH/tYQU57PRUFBdDHdpk2bhhEjRuCWW25Bhw4dMH36dLRo0QIvvfRShfmnT5+O+++/H2eeeSbatWuHyZMno127dvj3v/+t5Bk0aBDGjx+P0047DePHj8eAAQMwffr0atd7PJBJkiAIgiCcQPh8Pjwz6wgmPdCwRk4hh/wxFqe2cWHmzJnIz89Xfny+ih23+v1+bN68GYMHD1aODx48GOvXr69SvaFQCAUFBUhJORY+ZcOGDVqZ559/frjM2qi3LpBJkiAIgiCcQPh8PuQXhHBGF491ZhNsNhu6d/HgnXfeQVJSkvIzZcqUCq85ePAggsEgUlNTleOpqanIzs6uUr3PPPMMioqKcMUVV4SPZWdnm5ZZG/XWBaJJiqCkoQtO11EnQHG/qrNsTy75QSpT7eVBr9qVDh/ZrNnliObynv0qcTiESpv9vwIqLytE7vc15y1amv5zoaSriNrqZjGBmgyVsnjCXNdhI79LRpC0EOSLprBUdX6zdm9bJV1SrJ537FaFKjE5av0pR9iHlXqe/cew75ysP6jX/zxsNsw4//sLlPRlTb9Q0n1jf1LSf/ns9vDv8bvUvsnvqI5LK79B/Kw0v0F0vsSnOsnKSFL1X2WkoSnOUU0FTvrmJzVQhTFuu7nWL6tQ3QbtOKi2x0H/HAeS1bTBrwLfb4j9IrFQhdKsabIgIU4V0TpIR1Raoo7VIOnzIl9Vfg9cFJbE71fbVtZQ1T85StW+S9pp4ReJNUlB8/xW2EvUF8vKF1zIrba3LM78z5eD/ChpfpFCrMEKmp6PfBmsQj3VFiGEEKqhUyYDBnr37o333ntPOe7xmE/AeAXLMIwqrWotWbIEEydOxNtvv40mTZpEXWZ1660rZJIkCIIgCCcgQcNA0KiZSNwwAIfDgcTEqvlZatSoERwOh7Z6k5OTo63yMMuWLcOIESPwxhtvYODAgcq5tLQ00zJrUm9dIuY2QRAEQRAAAG63Gz169EBmZqZyPDMzE3379q30uiVLluDGG2/E4sWLccEFF2jn+/Tpo5W5cuXKcJnVrbeukZWkCDxHAnD+b0szhwWxW0ScdharS8cOH0U/j1HX+W20ldlRwuY5qwja7AMg4ldeviwzN4dpNhWb+VZgWyzdC1vTaNnfHqv2Df9j5HCpB4LkEoDNdcEf1Y3eNtrKzFvyE6k+3oYec0jNUNKITEbqijFcRbQcTN133plfIxpOS1TtfbcmZSnpb8hsEvr52Db8oIVkwVWsptkdBKeDMRSl3klhQxLVsCEtYw8r6exSNSSL67D6ieEwJK2SVXNdkksNMbO/VH3Wh/JU850719zdRVDdUV+FsCPmLgL4rbRyIRCKVe831q26q/CVkYsGMr85PZWvIvBryyFO/GQatdF7xuGFHH4L8xqbp+gbaOlqhPs+SOYtClsSjFcHd9DD31BzFwT8HdTqD5hfzy4JIj2H8DtfV4RgIKQHv4kKoxrXjx07Ftdffz169uyJPn36YPbs2dizZw/uuOMOAMD48eOxb98+vPrqqwCOTpCGDx+O5557Dr179w6vBsXExCAp6eg3YfTo0Tj33HPx5JNP4pJLLsHbb7+NVatWYd26dVWutz6QSZIgCIIgnIAc1STVjOpMkq688kocOnQIkyZNQlZWFjp37owVK1YgIyMDAJCVlYU9e475b3v55ZcRCAQwatQojBo1Knz8hhtuwIIFCwAAffv2xdKlS/HQQw/h4YcfRps2bbBs2bKwj6Sq1FsfyCRJEARBEASFkSNHYuTIkRWeK5/4lLNmzZoqlXnZZZfhsssuq3a99YFMkgRBEAThBOSocLum5jahJsgkKQJXfhmc/9t6b2MNEm13Zc2S4SSDPG2FDiXRVmW/+SIq12+lDzDLG+3WXNYG8NbZkJM0T0WqVsDbTNWVsFYiP0+Nj1B2SBWOeHLU8hr8orbPWUJbn4tpG3Wyev8H+qr1x+xRn4WzRL0fh4/7Xj2f210VNQ3p+o2SvjjlS5ixIF8VOXWNrzzsCAC8fLCfko7MXqxGVIEjX32l7aoEBiE3pUmXYnhJg5SkapC6NvhVSTcg0ROHeLGR+wRPEzV/Y69aPm935jAkgQL1BuJIjxak+wt61GfJYUkYdgFgI48EmhbF4tViHZDdwv2F2026Ir/6PAMlxx6YM0YdhyH65tgd9I2hvmHXFs4S0ghZfDdCFPbDTtpHy2+mm8KKUPlB0nGG6BuraaDou8UuALQKrFyhEJGPzuIx1hr1pUkSjiGTJEEQBEE4AQnBQLDGkyShJogLAEEQBEEQhAqQlSRBEARBOAGpHXObUBNkkhSBPRCE3Thql9d8DbFGyMku+lnHAtPzDPs90l30s8+Pyl3maz6WrHQUXJadfceoaWcxCzXUmy3OVcN+2H9QhS/xpIVgfyTcvAD5uuEbKosj7QLpbBql5ynpogaq/5U8p+qLx6O6/kFxC/V+b+v1sZIe3/AHbqApF8XvVNKlmkddtT0rvumipFPzjvVQcVO1LzyH1TT7sgl61fPsZ8kZpz6cVolqZ7TwUucQuw+lKOlgrFp/y2T1WdjpaReRqIjPs18jDkPiJ59WwTjWxbDmyNyXjuY3iceqxVo8hw4JkaiptIxCbZDfJIN0RpFhUdgNUJD0VCEK5xP0q+k4epTsDy3kpm8S+0Wi7wL8/KzU98Zw8XtKGiP6pga18/zsyG8Tf2OtQodooS6i9Pt0HKgV4XYNrz/ZkUmSIAiCIJyAhKCF/YwamSLVjBNgriwIgiAIgnDiIStJkRgIm56str+yyUdzgc+5aSmYl5odxRQrg819vHTM/16QeU9tHBXNpkM2r9GWd66LTTi8HTbxW9WEwNumC1qrBbqaqC4DygpVk4szRy2Pw4o41cDqCKjWPnRKPKKkh7XdrKQfKb1YrT9Bte+defpPSvraJPV6No8xJYZqE5qU3V9JB2kszUjfpKQ9u9X+iNzGzuYfl7qjXoO3yAfi1IcXE6P6DGjqzVfS7b1qyJTtpU2VtD9bde+AFPVhJXvUh1UQUO19brtqonFSmA5HMZlk6H7KEmgwxpDJp5hCW3DYEae5ycVy6zddHxOvPnt2AcAmMhud5zAljohXgbf4s7uAoJ8+Cj71ZmIPmH8H2PzG7zG7d+BvFJvXgjFq+3hLf8hl/g11+MidQhm3zyJWiMV5vv/jtc3fjKDsbqt3ZJIkCIIgCCcgQUNz/xQ1NTXXneyIuU0QBEEQBKECZCVJEARBEE5ADIhwu76RSVIkQQPhIcVrbLxF32oNlOzzrB2x1jyZo+mKtH3+JnmtbPcEb73lsCSeg2rfFDele2uuao7OO+VHJf3JzjZK2n6EQjEkkMuBWDXtI12JM17VwTT0qLErCkKqaKlJwwIlfWX3NUp6dINdSnoPaTEKQ6rOJt6uappu2X2+kt6w4xQl3aONGpbktl/6KmmnGskDZbEmz5raxq4oeMu/QWE6nA61bz02tS9dVMHeUnXLvytfHQsxLSluCJHvV/uqaayqgeIt864CNR0gCZQWNqTYTKwHZUs9UEFYEu3doespbU9QNV0N4tSxzy4NnKQr4leztJT8WVRetbbl3yB3B858tS88ueqzZJ2k+5A68FhjxG5LOBwSlxcklwJBL31T2RNJTTVIdovzmlaTTptcbnauNgnCpmkWo0UmSTVDJkmCIAiCcAISMqzdPVkhk6SaIZokQRAEQRCECpCVJEEQBEE4Aakdc9txsg3+TpFJUiR2hNfWtDAjvOZmFhYEur2c7elalBEn+2+h/NwetsdHtEdztl9D/yGMvYx0HKSDCTZWdSwOMuD7Q6Q5OqIKZUgWA3eqquto3eiQkk52q5qgQQ23KWmXTS3wF7+qo2mdpJaX4jR3NrSjLFlJN3Souptu5LuHff80TT2ipM9IUjVJWwvSTesPRsp4aBiyzyjt2bPfH9Jz+fzkk4r9+tCL8PmBlmp95CcoOVZ9dvl+EkURJUG1/p8PN1TSbjWqCUobqemQx/w9Q4jfGw51wacpP2m4DKovOVnV8bgd6suR71M1WKX+yjVHFeFwHmsg67UMDrFCeA+YhxdiP0Gsw2QNUshDYUbcFoYJzfcbVUd+mdgvkhYGxQJtcqANDXM/UfyNj3wVjpcPJdEk1T8ySRIEQRCEE5CQYdMmw9EiodtqhmiSBEEQBEEQKqBeV5ICgQAmTpyI119/HdnZ2WjatCluvPFGPPTQQ7D/b2nXMAw8+uijmD17NnJzc9GrVy+8+OKL6NSpU7gcn8+HcePGYcmSJSgpKcGAAQMwc+ZMNG/ePLoGhaAvz/8PbdndKgwJL9UGeemYt8+aL/tHs41fb6tZSysqgKJrk6mQt/aGyILioDAiQYrMvnFXKyXtzVKHob2ralNZ3mO2km7nilfSZYZq0thC0cg3lqguBooplgWb//5b0FpJ943ZpaSPhNRQHA62G9AC984C1bzXKEY1z7V0H1TSPzoaK2k2ofmSj/3OIVocdO++RHLfQDvinYUUlb5I7Zsy8iGw3afee9Ze9d5s8WQyob4powYkuNSwHQE6X3ggTkknU1dzWBVGCzvCFhU7m81Ni4PhoPfarb6oSV7VvGhQhXkFqvuJQLH6rthcHIZELd8e0d6yMtqSH6It9SXq+dj9atsdJerg4S38HEaEv1m8pd/KBMUSBmeAHiYltXBJmjmMKzC/XgsNRffL5+1++gjXA6JJqn/qdSXpySefxKxZszBjxgx89913mDp1Kp566im88MIL4TxTp07FtGnTMGPGDHz++edIS0vDoEGDUFBwzLfNmDFjsHz5cixduhTr1q1DYWEhLrzwQgSD9T/IBUEQBKE6hGBHsIY/IZkk1Yh6XUnasGEDLrnkElxwwQUAgFatWmHJkiX473//C+DoKtL06dMxYcIEDBs2DACwcOFCpKamYvHixbj99tuRl5eHuXPn4rXXXsPAgQMBAIsWLUKLFi2watUqnH/++RVXLgiCIAiCYEK9riT94Q9/wOrVq/HDDz8AAL766iusW7cOf/7znwEAO3fuRHZ2NgYPHhy+xuPxoF+/fli/fj0AYPPmzSgrK1PypKeno3PnzuE8jM/nQ35+vvIjCIIgCCcS5cLtmvyIbrtm1OtK0gMPPIC8vDycdtppcDgcCAaDeOKJJ3D11VcDALKzswEAqampynWpqanYvXt3OI/b7UaDBg20POXXM1OmTMGjjz6qHbeFQrCVayh4u2qUoT2iDf2hbUGwSptppDRbPmXVJDSsn6LzJDYwaIt73C9qOrcjFe+nUBXfqLEkPLStO/lcddLKGiTmP8VJSvpnvyqC+ixXDQNyoETVuVyY/o2SPsWdo6R3lKm6m6+L1W3v58Z/Ty1SOzC3SL3fNomqBilE/6t8n6uOd1eh2v9F6ceer+cwVU3DJKBKYLRnzyFPfGVqW7wkevr0cFv1POnJytqqmpycggQlneBVNUjxsWpImP3F6rP27Cd3EeoOek0jxLAGSQ8PRBeQi4AQb/l3UxgRuvxwsfqsWZMUIM2Xwe8ibbO3e1W9XTAi9EiInhU4PE+hej72IPnqsNBZ8hZ/xiqMhxZmhDVIhJW7Ck1PZuVygN2mcHglt5p2qENT/45GuL7+bYUlEXNbTajXlaRly5Zh0aJFWLx4Mb744gssXLgQTz/9NBYuXKjks7EPIsPQjjFmecaPH4+8vLzwz969e2t2I4IgCIJQywQNG4KGvUY/4gKgZtTrStJf//pX/O1vf8NVV10FAOjSpQt2796NKVOm4IYbbkBaWhoAhHe+lZOTkxNeXUpLS4Pf70dubq6ympSTk4O+fdVAoeV4PB54POZO7QRBEARBOLmp15Wk4uLi8Fb/chwOB0Kho8uyrVu3RlpaGjIzM8Pn/X4/1q5dG54A9ejRAy6XS8mTlZWFrVu3VjpJEgRBEIQTnRDsNf4Rc1vNqNeVpIsuughPPPEEWrZsiU6dOuHLL7/EtGnTcPPNNwM4amYbM2YMJk+ejHbt2qFdu3aYPHkyYmNjcc011wAAkpKSMGLECNx3331o2LAhUlJSMG7cOHTp0iW8261WCJlrEVhLwPkRVM8H4lR7vyatCLGjpCgGOoWNtmkORKwcmpjn18KSUH2hhqqOxZVNIiaLW/np22ZK+pV01TdPuitXSbPvnryAqgvJKlZ1MQ29qhBnbIOdSnpHmRqWZEnemUr60cZq2BPm01L12buc6rNMdqm6HSZrf7KSTopTOywYc6x8G/nGYf2ZQW+4nWQpmo7EqbY9t0zty21ZaUraSTqO+GTVB1RBsSoi8jrVsWEnkdAvh5KVdIz6qBUfUUAFejuL0BwM338oQe0gT5J6g3byq+T3qR1cVKyuULMmSZMWkubJHeunBlL7Ir4jBn1THLlqW+JJK+gsVO8tEK/6aGJNUIg0PPaAhU8qc8lR1LCfIw57EnKZt499z1l91zTNE+tSbZUl6g7RJNU/9TpJeuGFF/Dwww9j5MiRyMnJQXp6Om6//Xb8/e9/D+e5//77UVJSgpEjR4adSa5cuRIJCcf+8D377LNwOp244oorws4kFyxYAIfDXHgoCIIgCCcqof/pimqCSJJqRr1OkhISEjB9+nRMnz690jw2mw0TJ07ExIkTK83j9XrxwgsvKE4oBUEQBEEQaoIEuBUEQRCEE5AQbDX2mC3mtpohk6QIDLsdBmuLyuHjbM8m+zfHQeK4RwzrerT8Fj5GItvDr4Tmi4Vt7xa2e93XjNrWoJe0Abmq1iHkVvMXnqI2yP0l6bNK1fLe2d9VSReVqRqnIr+abpl0REn3aKi6eHi26WaYkUL90SN2ZyU5K2bW/vOUNMfzauRSNU+MkzRc/kT1vBEfqXEirVssj0P12hDJw/yJ6rNp00L1EeWjuHaBfaqPKRttEvWX0SeF1vrjXKrm5ohfdeQU3K+m2XdN0Ev6OPbpxZokh4XuhDVN5Acpxqu210qKwqYNP8dmo/a4Yij4HlFGmqeQ79gDdR5WzyXuVBsXv498LHnom+RiP0vct1YaJNImWmiWrL47mibKba63Y/jZcmw5h199tqythPYNr9xv0/GaeJSHFqkJEpakZtTr7jZBEARBEIQTFZkkCYIgCMIJSBA1cyR51Jlk9VaSZs6cidatW8Pr9aJHjx745JNPKs2blZWFa665Bu3bt4fdbseYMWO0PP3794fNZtN+ymO3AsDEiRO18+X+EusLMbdFYsexaSOZ13STFC8Fmy/Vhth8ZmGu0/3eq9dzmJTI8rgtljYCi62xWl9Q+d5cdRk7j9oeSlFNCi2bqWE59sQ2NG3e97+qL8lp6Wq4mcfa/J+SPttbs7n/0G+vVdIeh2q2OKf9G0o60a6aiL47pIYVaddAvd/WngNK+khQ3WbP5sYyMok5446ZgOwB1ZwTIPNXkMJ4lCWQe4J01R1Cx6T9SnrrEbXvPYfUtpU0U+1dceTugN0fxJILgIOl6r27j9A2b/5CWTxaNu1abkunLf0oUCvMM9QwKXaXej9aJA0HuQqh8tn0za9awE/mtRI1HbP3WDpxl3qx94g6TjXzFzc2yH1lnta2xJdZhBkhc54WdoTdL7C5yyqcEl9PLgvY/UWICrQH1QK1T66JSwDtG1tHlPs6qgnV2d22bNkyjBkzBjNnzsTZZ5+Nl19+GUOGDMG3336Lli1bavl9Ph8aN26MCRMm4Nlnn62wzLfeegt+/7Fv16FDh9C1a1dcfvnlSr5OnTph1apV4XR971KXSZIgCIIgnIAcDUty/IXb06ZNw4gRI3DLLbcAAKZPn44PPvgAL730EqZMmaLlb9WqFZ577jkAwLx58yosMyVFjYG5dOlSxMbGapMkp9NZ76tHkYi5TRAEQRB+xwSDQeTn5ys/Ph9H9D2K3+/H5s2bMXjwYOX44MGDsX79+lpr09y5c3HVVVchLk7dDLJjxw6kp6ejdevWuOqqq/Dzzz/XWp3VQSZJgiAIgnACEvrf7raa/BiwYePGjUhKSlJ+KloRAoCDBw8iGAyG46OWk5qaiuzs7AqviZZNmzZh69at4ZWqcnr16oVXX30VH3zwAV555RVkZ2ejb9++OHToUK3UWx3E3BaJ3RbW31ht2WeX/oXN1L3VnjzV3u0sIi2D1W5ZTU9AGViSFOlywCK8QMit2njtpC2wtP1TOABnCYUlSVa1Ec4stW/2eZKVtOtXVUjT7Mx9Svq9jm8qaY9N7fuazvULQ6VKenDa90o6w6NqiliDxCR61PK8DlWHE2dX/4PLzO2opO0UmcLXkJ6P/9jz4y3yJY3UdCBevdaRqrojaNNYvTdm3+Fk9Xo672msapp85AKgQZx6nvsip0ANGePhMCTqCr0SkgUAbAHSyfB7ZWVp0OIBEaWkkaJ3w+biA+QOg8K8aGmqP0TvvTNP7fGU745d76JvCusa+T3WXHmw9JC3/POtsX6L7jXoVdtqVR/DGiiEzF2RaC4BqD0On1qew2/h0oC/qSZjp4YWsCoTMmyalipaDNjQu3dvvPfee8pxqyDvNnYFYxjaseoyd+5cdO7cGWeddZZyfMiQIeHfu3Tpgj59+qBNmzZYuHAhxo4dWyt1R4tMkgRBEAThBKQ2/CQZOCp+TkxMtMwLAI0aNYLD4dBWjXJycrTVpepQXFyMpUuXYtKkSZZ54+Li0KVLF+zYsaPG9VYXMbcJgiAIggAAcLvd6NGjBzIzM5XjmZmZ6Nu3b43L/+c//wmfz4frrrvOMq/P58N3332Hpk2bWuatK2QlSRAEQRBOQGpjd1uoGtePHTsW119/PXr27Ik+ffpg9uzZ2LNnD+644w4AwPjx47Fv3z68+uqr4Wu2bNkCACgsLMSBAwewZcsWuN1udOyoygnmzp2LSy+9FA0b6q5fxo0bh4suuggtW7ZETk4OHn/8ceTn5+OGG26I+h5qC5kkRWDYbLovj/JzDvNFt+ImbD9X88eVmvvkYB2KjcOQsJslbk9ku8n5iuZ+387aBQuxAJ13+NS2+VLUYWQjXzNOVZYCX4D8p2SoOpkPO71DDWANUu2yk3QgZRTLY9G+Xko6LeMDJd3KeURJ909Vl4YbOQuU9EWxaod8mKdqmNi/CwuBbIePabyCFGYkoG4UQShB1a00SlTrZr9Fv5YmKWn/QVV/5SI5VnKM2vbDeapfoYQGqsiomBpceFD1k5RMw97fgA7Eq3q3UBn5D/NTuox955DvH36NOKwJo7kgMxeyOMmvktultr8soD7cAD1sVwFpnCK+C5pvNYK1g/zeshaxsm9fZRjsl8gqbIiVHyS1a7RvpOYHib5jHHZE023ys7MMo2LhP+44UDt+kqKfJF155ZU4dOgQJk2ahKysLHTu3BkrVqxARkYGgKPOI/fs2aNc07179/DvmzdvxuLFi5GRkYFdu3aFj//www9Yt24dVq5cWWG9v/zyC66++mocPHgQjRs3Ru/evbFx48ZwvfWBTJIEQRAEQVAYOXIkRo4cWeG5BQsWaMeMKkwiTz31VNN8S5curXL7jhcySRIEQRCEE5Dy0CI14XgF4/29IpOkSGwIm7U0F/yaC3syMdFScVmcuUlLi0jtp3Dm/F6w9S1osv3XYtlcM+XxVk+rSOe07O0q4nshE0KnIiV9fpvtSvpvqaugkoDa5M0itbz/O3iGkv50e1slHbNDNQk51eZjVNqtSjqQpD6LM7v8pKSHp31q2r4/JP6gpN9zqNti7cXqYHAfOdb/urlNfRbuBNVHQJxbTbvt6sDdmafqBNyH1GfpJ3sYD7XYWLV8NucdKlHNa66DqimV/x6weYzNW/YYMr9RCANDs1VSklwIwEPvOb8qIfOXg/9JDlH+YIhMzRzCJ6ied6mWWuU9NziMCO/QZ1ce3DYLNyc2dgnAxbG7AzJfcZgRzRUJ+5NwmZfHY0NzXcKyAoafPcsM+DtI9UW6ENDcJdQRIdgQquEk5/gbCX9fyCRJEARBEE5AQrWxknS8nDr9ThEXAIIgCIIgCBUgK0mCIAiCcAJSO84kZSWpJsgkKRKb7ZhdWtt+SluLeZs92f8DqvRC227Kuh5bqYX9n/UDpCuK1A/oW3O1fcum57W2cdtZi0Du/oOJqkbH/qvaGfa2av7dAVUzlEqhKzgMyfdlqkjo5YPnKum3t3RX0rE/qdezxij1ELtMUPs2EEMarGLuT1Vc8e3Ppyrpe5qrmqe7E0jAVqS+hkkUKaTQq6YjXSoE6RxvkXc6SbtGS++lQbVv9h9QvfLGUF8Zp6ruGny0hT3eW3HQzHIOF6tjwXNEPe9rQBewRog0O04PjRWvmg4lqPfrK1RDMRjsMoDChNjYXYVF2BPe8s/9XVam9leQ7seWpz6PmIPUnkgtDOsmadyypkdDC/NBmiEPtY3Ks/OWe/5b7qaQLk5zzRETcllopgxzTRY/LO07R2nWGfF3LvJvQE235VeVo2FJRJNUn8gkSRAEQRBOQGQlqf4RTZIgCIIgCEIFyEqSIAiCIJyAHDW3ye62+kQmSZEYRtiOrfvcUAcq2+NdhWp+F0cCIQ1RiO31Li6fdD1l5EeJibC/2yiv4VYfM4cH4Lo1Wz05aWItQIC1Cz413bC9KrJpH6tGl/7X4TOV9AMHWirp/TsaKWnvfrV81rWkqLIUDfYfUxZLoSTUSBuaUZ+v52+YV43Egbj9/JFSdSchegt9yVQfhcqI1Lv5GtE4jCVNDvnlyfepIqYANz5XdbwUoogwCXFq5wTYr49DHXvZ5KMqL0cNW5JEfV10Kj08O+lg3Gr5ceSXqWGsKqIqDag3kOVTOztEfWuQ3yRN50KaJYOfDftlYt9EpOFCqdp/3kPUn8WkyYo47fBR35DGxzLckGXYDkoHzcsPuslHlYVfItYo8XlOW4Up4fuxW30H+P5Zu8nfyYhkTX0XVZUgbAiKn6R6RcxtgiAIgiAIFSArSYIgCIJwAhIy7DU3t4lwu0bIJCkSA8fCf1iMSzaHJf2o2g20pWNaqrbzXuJoI3Dz9t/Ic+QuwGBzGi8jk+lPM2Fb2LSdZBKwkYnnghbblPT0VUOUdOw+CruRr5bfgJb9QxSKI6ju6oZf3cUOG1kqXYVq2knuFzhcgquElv1pGT9A9Qc95uEYuD0GvYVlcWraTvnLEiPcPSSpjdGi0hMxLjX/4UJ1S777iPosAvFqeW4yp/nK1MYfKY5R20rmJdch1fzFpku7h8KM0Jb5hATVBUGyl9Ie9T3MJnObw0kVeqk+2vIPPz0c3lZO7QuRBwQbhVVBsZrfma+mPWSq1cMZRYTG8HHcEWpqlN8ULawJh/2ge7fcos+hO+g94PeEzWMOci3C9WsuEKw8HkQZhkQzFxoV/16XhGrB3Ha8TIO/V2SSJAiCIAgnILWxkiTUDOl9QRAEQRCECpCVJEEQBEE4AQnWQoDbmnrsPtmRSVIlGHY2UJvn1+z5VmFIeBs56WA0eznvLHbQtvsIjVSIt+KyO34LrULQzefJPQG5R7AHVJ2Kza9eP3/T2Uo67TMKjZGi1hagUBu8DZ2fhcOvpiPDdhxtEJ0njRFrfvj+eYt+kDRRAa+a38G6FIvwCBQZRNNcafXHHxs8nnj15o2QWraXwnbwB7N4v7olP570YL7G6kDN3p+kpF2/qoKsoIfHvZqOV70/aHqykJ/GLt1PIKieLyMBWWGZ2nkH8tT7KytUz9tc/PA5RA/pYsi3h+YygH1/UNJzUG1vbJZ63k76u9IG6rsXc+jY8zBsFmFDWBNkgaaj5HHrMNfwaDFb+BvKGh/NpYBFeXxaC6tCGTgMip81VebhlzQ7S2R7o+zb6hKCrcaaIhFu1wyZJAmCIAjCCUhtrCSJn6SaIZokQRAEQRCECpCVJEEQBEE4ATkalqSG5jbRJNUImSRVguaTg89TmBG2/xsWuiCrkAFmfpCOZqBkhF4gRH6SdP8iVBb7cLIIR8DvXNCj3msMheEobKjmP9JOPc9+ixwUqoLbw+fZzxBrhrinWVthL6XQD3x/XB6HL6BkQHUVpNdH/mDYb5L2bO2VjxU7ieHYp4qLBFclZaoAypmnPjsHh3IgnUjcNlVElPyTWr7m+4afHfkXy2ul1m/PVdvHmqAim+rXif0w5TrUzveXkODLTz7BANPz+p8X0tFYrMXb8tXBmbhTvT7pJwrzEqvmL0pT04GYYy0qiyW90kEaSKTV0zRK/Fng95zGLY8FTdrI2VkzpIUpMT9v5TvO6n4Y9gfH3z1HKY9l1lQda8/xmnaEYEewhgYf0STVDDG3CYIgCIIgVICsJAmCIAjCCUitmNtqqS0nKzJJEgRBEIQTkKMuAMTcVp/IJCkCm2GE9TtGUD9ndW0knJv9KFnGCdLip3GBajLSN5KV3onPG161MRxrjP0Iaf5E6N459lpauhqQ6sieJkrar7reAYXv0v0YseaH+lKLAcV+i+j+db9QKiHWZlhoLYLk50nXGFH57AeKxwb70PJE+MSiyu2kX+JxlJeranpiD6vn3fnq9Slfq5XH7VcfhrNITWv6K9LucTywZHISFbfffCz649X8JamkYaKxEst6L9aPxbIDMjXJzyZUQu1zk7AmRk278tX8niMcuI99BanpmMNqfn/8sfJYG+fwRffeM0HS7Ghx9ULqAfYzxDEiA/RdYb0a4yqiscIaqShiq1WI1f2TBslMe3i8tNBBw4ZgjYXbtdSYkxTRJAmCIAiCIFSArCQJgiAIwglI7WiSxNxWE2SSFIHhsMMo3z7P5jPez6qZRHipls7z5bzqziYdqyVSk+27vGVcX2Y3N2lY2vqobxw+XoZXsx/Mi1PSHAnCVUJpCivioHACZXEU1oPDeJAFhbfks82FXRBoW/TZBENvDW9zZwsPm9/K1EgZ+lgwjwqjNJ+zetxq4wMhGpeF6sPxqJZQeMm8wyYXNrXqZmYO6aLW7yBzm+ewuk/dlU+uLzRTpXq+bJ/6MLRQFZr7BXN3GHx/ZfHqYPLH09jzqucDlHYVqeU7S8jdBH83LNoTaZLi8Dp6mBBK87NkUx+7HdHMXfRs3WxOI3NbDJnj6L305pJ5jWUA/E0ktG8sla+ZC+k91cqzCLuiyQyOAyHDjlCNPW7LJKkmyCRJEARBEE5AgrBpvs+iRSRJNaNak6TVq1dj9erVyMnJQYjEfPPmzauVhgmCIAiCINQnUU+SHn30UUyaNAk9e/ZE06ZNtSVaQRAEQRBqTggSlqS+iXqSNGvWLCxYsADXX399XbTnxIEnf7xTWNseamE/Z+1BiLZOc3nRYrKmaicdSIi1B2S7d5SobbNb2OJZm+AuVPMHilTRkINGXWwW1U+6EdYAseZJCwNC+W2kRWCdCJfHGqKgGolD0xSxFqIsifovSdXdBEvVBroO0jZ2B7koSFBvwBahOXO71HOxpEnKyU1Q0nG7aEt/jtpW3kauuVfgEDZ+GjyU9DVgzRDdexHdG+lSNF0MbTO3+6xiZajXO4vV+rQQPkG1PCe9CzE5VDq9t4E4tX+5/dxf7ILAYH0gvXqR+jUb3zvDejEqm78Dml6Li9O0i2qS31PGWWr+bHVtJDeA6rNwzcFaRkvNFp9mDVaEC4Og/fhsDDdqRZMk1ISoe9/v96Nv37510RZBEARBEIQThqgnSbfccgsWL15cF20RBEEQBOF/HPW4XbOf6objnTlzJlq3bg2v14sePXrgk08+qTRvVlYWrrnmGrRv3x52ux1jxozR8ixYsAA2m037KS1VgzxHU+/xIGpzW2lpKWbPno1Vq1bh9NNPh8ulmgqmTZtWa40TBEEQhJOV2vC4beFovEKWLVuGMWPGYObMmTj77LPx8ssvY8iQIfj222/RsmVLLb/P50Pjxo0xYcIEPPvss5WWm5iYiO3btyvHvN5j+oZo6z0eRD1J+vrrr9GtWzcAwNatW5Vzv3URt2GzwajkHjSfImXshENNhrykxSD7uY1CZdjL2LuOOZp/moh2W2mIGGcxaWhIN8FaBNYSBGJUXYW7QL2+S9u9Svq7nFOUtK4xMvevwt8Mhyr50fwU8fW+BpTfS9oIN6Up1ITNbfGsWKtRRjqVAGsd2D8M6VioPlvEeadDbVthqSqgsu9Uw5A02qZqcpwFqoaJNT/8PvC4K0tUH16QQ1VovnVIw0NOrdjnlo12z/LYduSR3iuGPmnsFonCpNj5PWJtIGukLMIDufLJyRbBfpX43eL+Y79Kyv1bhLvR2sp9Ye4+TdP8sB6NtYyafo2eFft10sKaWPi4Yvi9Zv9mWn67+XdM11hxSJwITZL/+GiS6stP0rRp0zBixAjccsstAIDp06fjgw8+wEsvvYQpU6Zo+Vu1aoXnnnsOgPkOd5vNhrS0tFqr93gQ9STpo48+qot2CIIgCIJQBwSDQeTnq0E1PR4PPB6Pltfv92Pz5s3429/+phwfPHgw1q9fX6N2FBYWIiMjA8FgEN26dcNjjz2G7t2713m9NaFGU9RffvkF+/btq622CIIgCILwP8rDktTkB4YNGzduRFJSkvJT2crMwYMHEQwGkZqaqhxPTU1FdnZ2te/ltNNOw4IFC/DOO+9gyZIl8Hq9OPvss7Fjx446rbemRL2SFAqF8Pjjj+OZZ55BYeHReA4JCQm47777MGHCBNiP09bIusAWPCp1A1BBKIjowpKAzQy8rO4hEwwv65OZAbw0zEQWb2WE5rAipWTO4a25FjZx3jpcmqL2xa+FiWp5ZL7icAZWW/xDFIYkEEft9VDfUSh4O8VFCQXp2QVt5mkKUWMEzMc8mzXspWTSIvOa4aILqH1OzzG7wuGD6hZ/+yG187wFalG+JLJR8BZ1NtXyrdM49yeY37snl1xd8DZ0DmVBW+I9R1QbCo9NG1k+9S33VL+27d08TAhjFT5IC2Hj5mdNJh82SXHYF5P3nk2fbK9icxmHhGF006p6nt0l+BLN+4rDgGhmdDZtsumTzX0BfraUtgjvo5XHEgq6XwfJDlxFx+7XZuEuobY4Jr6uPgaA3r1747333lOOV7SKFAnLZwzDqJGkpnfv3ujdu3c4ffbZZ+OMM87ACy+8gOeff77O6q0pUU+SJkyYgLlz5+If//gHzj77bBiGgU8//RQTJ05EaWkpnnjiibpopyAIgiCcVNROgFvA4XAgMTHRMi8ANGrUCA6HQ1u9ycnJ0VZ5aoLdbseZZ54ZXkk6XvVGS9TLPgsXLsScOXNw55134vTTT0fXrl0xcuRIvPLKK1iwYEEdNFEQBEEQhOOB2+1Gjx49kJmZqRzPzMysVR+JhmFgy5YtaNq06XGtN1qiXkk6fPgwTjvtNO34aaedhsOHD9dKowRBEAThZOfoStLx3902duxYXH/99ejZsyf69OmD2bNnY8+ePbjjjjsAAOPHj8e+ffvw6quvhq/ZsmULgKPi7AMHDmDLli1wu93o2LEjgKMhzXr37o127dohPz8fzz//PLZs2YIXX3yxyvXWB1FPkrp27YoZM2YoNkQAmDFjBrp27VprDTvRMay0VywXYJf7tF3VciBrW5UpnEKkDol1DKyD4FAPWsgVqtvKHszboItVW/7+XeqeeyNOFQ8E4tQKS9JIJ5KkdpaDtsTzNvhggG6IYCkHSik/aY5sXtI0Uf3acniJej+eQ7TNXfWdBl8KhSGx0/MpI83WnmPb+lN28JZx9dqShmpdR9qo+T2NVA1Twh713lyF5u4OOOQL6zh4LPnjKYRNPvUla5TIvQS7qwi5WBxorhXRdDxa2BPKz9vcORIGhTEJkdaQdUFBr9peDp1hpQ9U2mKhb7JbyWZYosSvjdU3jOCxx+GFAl7+sNC495Cmiv468XvDGqQQuwTgoWuh1dQ1XGr+I6cea3/Qd7zCktRP7LYrr7wShw4dwqRJk5CVlYXOnTtjxYoVyMjIAHDUeeSePXuUa8p3qQHA5s2bsXjxYmRkZGDXrl0AgCNHjuC2225DdnY2kpKS0L17d3z88cc466yzqlxvfRD1JGnq1Km44IILsGrVKvTp0wc2mw3r16/H3r17sWLFirpooyAIgiAIx5GRI0di5MiRFZ6rSFpjWPyD8uyzz5o6mqxKvfVB1NPhfv364YcffsDQoUNx5MgRHD58GMOGDcP27dtxzjnn1EUbBUEQBOGkozbCkkiA25oR9UoSAKSnp8suNkEQBEGoQ2pnd9tvOxJGfVOlSdLXX3+Nzp07w2634+uvvzbNe/rpp9dKw+oFG46trbGvBtbl8LhjXzjkk8RZQlqDMg6/wP5R6LyFjsj03wVtGdTK7xHpLLg4J+tA1KSrgHzTkG7ERn6F/LQz1dZQjdni8ajCF5dTLb/UpwpJ+HZddD37RQq56Q5L1M61H1bLdxarjprceTBNu0irESTdC/uL8ZGvHnuRmr9hxCvoIo1OkMJ+uAvVdFmSWtaRzmrflDZUPwnJP6htictWw4A4feR7hjQ2gVj1+iNt1XT8L6SRylOfRVk8PQvNV46S1N6jaDVKrEGygt8FfyKFI6Jn6ywifRtrjjQNlIl/Nsqr3TvbCSzuzSoMCGt63IX0jbLwHcQhZ1ivpus8zf0ksQZJwyR0EwDYqT9YA5V9pnqg44Afw7+XFfnxw9MW9dcCtTFJkqWkmlGlSVK3bt2QnZ2NJk2aoFu3brDZbBXaH202G4LB6GKQCYIgCIIgnIhUaZK0c+dONG7cOPy7IAiCIAh1S205kxSqT5UmSZHb73bv3o2+ffvC6VQvDQQCWL9+fdRb9fbt24cHHngA7733HkpKSnDqqadi7ty56NGjB4CjivlHH30Us2fPRm5uLnr16oUXX3wRnTp1Cpfh8/kwbtw4LFmyBCUlJRgwYABmzpyJ5s2bR9UWUyxc6HMYEcPO28qpOA7/YLE9VVt21yISRJynrbp6+AIqnE2LfK+MZhokE0uceu+uQzRW4tlOQCYU2tLvcasuANwOdbXS7VJNRkfyY5W075Aa18ReqLYv9oB6vzEH1OY5fRQ6ophNJjCFv3HBBhSqgt5CZzG1h8IWRZot2LzGJhNXsdr2RPofxxZQK/c1Vvv+UBd2NUGmRzYl0hZ/DivS+Cs2l6n1+Rqo7XFQ31uFstC2zLP5iky/bPJhM7f+LpD5Ml5tb2ky9Rc1x3OYyrfYVq+djyjPzqv2Fq46+DuguRAIsXmKG0P5ybzGpkMOxcQuCvg7xeY4h2p1R5BDvNB7Y2e3KvxseSzQ/R88Xf0uRJrXAGBQo2/Dv5d4A/gP6p5amSTV1Fx3khP17rbzzjuvQqeReXl5OO+886IqKzc3F2effTZcLhfee+89fPvtt3jmmWeQnJwczjN16lRMmzYNM2bMwOeff460tDQMGjQIBQXHglKNGTMGy5cvx9KlS7Fu3ToUFhbiwgsvFNOfIAiC8JtFdrfVP1Hvbqss2NyhQ4cQFxcXVVlPPvkkWrRogfnz54ePtWrVSqlr+vTpmDBhAoYNGwbgaFiU1NRULF68GLfffjvy8vIwd+5cvPbaaxg4cCAAYNGiRWjRogVWrVqF888/P9pbFARBEARBqPokqXySYrPZcOONNyoRhIPBIL7++uuo46u88847OP/883H55Zdj7dq1aNasGUaOHIlbb70VwFH9U3Z2NgYPHhy+xuPxoF+/fli/fj1uv/12bN68GWVlZUqe9PR0dO7cGevXr69wkuTz+eDzHVvLzc/Pj6rdgiAIglDXiAuA+qfKk6SkpKN7hw3DQEJCAmJijuk83G43evfuHZ7cVJWff/4ZL730EsaOHYsHH3wQmzZtwj333AOPx4Phw4eHowFzBODU1FTs3r0bAJCdnQ23240GDRpoeTiacDlTpkzBo48+ato21gBpWgVeTePttazbCZnb6+0U3sEytEio6nuVNZ2Gtq2Y3RtwXeppbesuu/MnbQFrfArSVfFAAKrOxUXNKS7xKOmEBuqkNr/Eq6Td21RNUkyOWh7raOwBctdQar4t3OqbpYV14UgYXuqvEvU8tzfmIGu4jv0acvE4Ys0P673U/HFZVHRIbXxxM9VkfbCrqttI+VYt31WkpsviOCSLueaH3wsOccP36z5C7iaovECC6q7BWUA+A6y2vbNejzRNHGojhjRHrLkKuVnjRTogun++n8ixapCrCCvxhPbN0jKoSdZT8d9afhbahmf2SMBuTPjerfRiXD5/Mxn+rNFrdIDG8in9dynpxp5CJb2loGX4d38hjaM6olbCktRSW05WqjxJKjeJtWrVCn/9618RGxtrcYU1oVAIPXv2xOTJkwEcjf2ybds2vPTSSxg+fHg4H5v3KjP5VTXP+PHjMXbs2HA6Pz8fLVq0qO5tCIIgCILwOyRq4fbw4cOxb98+7fiOHTvCgeyqStOmTcMRgsvp0KFDOHBeWloaAGgrQjk5OeHVpbS0NPj9fuTm5laah/F4PEhMTFR+BEEQBOFEotzcVpMfy6VvwZSoJ0k33ngj1q9frx3/7LPPcOONN0ZV1tlnn43t27crx3744YewG4HWrVsjLS0NmZmZ4fN+vx9r164N65969OgBl8ul5MnKysLWrVuj1kgJgiAIwolCbUySxNxWM6Le3fbll1/i7LPP1o737t0bd911V1Rl3Xvvvejbty8mT56MK664Aps2bcLs2bMxe/ZsAEfNbGPGjMHkyZPRrl07tGvXDpMnT0ZsbCyuueYaAEe1UiNGjMB9992Hhg0bIiUlBePGjUOXLl3Cu92qA2t+tLAgbvKDpPnk4OvZnw0Le8y1GnrYEnOfJ6bnNL9IdJrL5jAkBIcxsfKzZM9VNUje/aTT+EXdJVmUoepOPI1UFxT5+9SVwMZ72X+LWj+HM9C0FSQ3YM0S5w942C+Ver2TdDWePNbxqPnZN5C9rHI9G5fNmiR+9kFqu7NUrTuB+65M7azSxur5/FakcfqVw6Ko5YdId8LtdfhZ00R+l3LpYVqEFXEWq/o3G7kFMUCDgfqLNUSBGPMwKY4SC7cjFjIBro+1jaHI9lHTedxpOkgXf1O4bWqSFyA0rR1Dz4LDfmhhU/g7pLWXv5EW+i1qjj2gnj98mlpe1/PVf9DPafCDkt5coPr821N4TPcaKCInTnWEYdhq7OfIIjKPYEHUkySbzab4KConLy8var9EZ555JpYvX47x48dj0qRJaN26NaZPn45rr702nOf+++9HSUkJRo4cGXYmuXLlSiQkJITzPPvss3A6nbjiiivCziQXLFgAh8MquI8gCIIgCELFRD1JOuecczBlyhQsWbIkPAkJBoOYMmUK/vCHP0TdgAsvvBAXXnhhpedtNhsmTpyIiRMnVprH6/XihRdewAsvvBB1/YIgCIJwIlLuELImiAuAmhH1JGnq1Kk499xz0b59e5xzzjkAgE8++QT5+fn48MMPa72BxxPDYQ+bwbQt/9FuFSaTE5useDuuVfl6yACT/FbRvjlcgLbsHmVb2ERBy/psTorbzZHlzc1ZpQ3V/L8eUUPZ2/0UKiKO6yfzFoXq0ExUdPsBD5tc+Nmp+TmSvRYJvjjKsUU4/JU/4ECshWnUzyYL9XwJ9XVZgnreVWA+dnzJVCHZaLxkLuOxxKZGfyKbtyzM4Dy2y6Jb3Q7GqB3iTzT/RLqKzO8n5LTY8m9l0jL5Tmj3ztYsC7O3jUz8Ic3Ez1eYmza1NDeIy6Ou5fdeczngtnhPqLojbdXObDpwr5L+c6OvTYtr7j2ipFM9xywoPk8ZPjZvTa0QQs1dAAg1I2rhdseOHfH111/jiiuuQE5ODgoKCjB8+HB8//336Ny5c120URAEQRBOOso1STX6kZWkGhH1ShJw1KN1uW8jQRAEQRCE3yNRryQBR81r1113Hfr27Rv2mfTaa69h3bp1tdo4QRAEQThZqRUXALK7rUZEvZL05ptv4vrrr8e1116LL774IhwDraCgAJMnT8aKFStqvZH1AutyOLSHFprDfLsqw9qJkJ20Fya6EwB6OIWI9rEWQAuxwudhro/SwpoQrMlhbYKrUL2+OJXCcuw23xqc+LOa9h9Ut/zH025c1hxxmreZ62Fb1CRv8XcXkC7GYmszh9pgQvQWcogaMw1YkHQamusIujd/gnq+KJ36NpldAKjnvYeobdTWQIyaLkpX0548c/cT/nj1QH6Gmt9zRB1szkLz//MMu/n5YJzqjqKoqRrGxEHuIJxF5mFQWD6ibbvXMphrlExHDmuOLMrSoPfUzpqjQHTfME1zxJ9E/uZZhGCxCgfE4YMOdlHHRps/7lTSI5p9oqQd5DMhP6iGN0pxkpgyglKXVUyU2sEwUGMXAELNiHol6fHHH8esWbPwyiuvwOU69oHp27cvvvjii1ptnCAIgiAIQn0R9UrS9u3bce6552rHExMTceTIkdpokyAIgiCc9IRDi9QAWYmqGVGvJDVt2hQ//vijdnzdunU45ZRTaqVRgiAIgnCyc9TcVrMfoWZEvZJ0++23Y/To0Zg3bx5sNht+/fVXbNiwAePGjcPf//73umjjccMWMnR9yf8w2EU+n6fT9lIW5qgZQqz7YXu8Fl7CPFyBPRShlWA9FeuXWJPEYUkCLAZQk5oWgsMRBNhPEF1O5nxXkbn+ykX3zuEGuH3OEvOwHrqGSE2yVkILPeFT2xskP0qs6dJ0JtzeUvP2sZ+mYIRGivVV3BmlKeq1rBHyJ6v34iglvRiFLdEkNV46T886NkdNu/PVh8/vVdBD5auSIe1ZWmv/6NlQff4k9RNY3EQ97yxWy4vRxjqPDaqfPxta6BA6ze8q64Yixx4vEPA3xCJckK6XovLor4Pml0n7zsAU/uZp2kd+tKxBovc6v5VaYbsBPyvp25qtVdJemxqiZm9ZQyUdZ1cfXob7gJI+EjwWLsntOE6apFpxJinUhKgnSffffz/y8vJw3nnnobS0FOeeey48Hg/GjRsXdew2QRAEQRCEE5Vq+Ul64oknMGHCBHz77bcIhULo2LEj4uPja7ttgiAIgnDSUjsBbkWTVBOqNUkCgNjYWPTs2bM22yIIgiAIwv8IGTbdbUSUiLmtZlRpkjRs2DAsWLAAiYmJGDZsmGne+Ph4dOrUCXfccQeSkpJM855ohFz2cKwlKx8hbO+3hSx0QByDifQAzjzVXs76Ak3Xo/n2OZY/2lhg3DZbyELLwPGxWEtAxWuamyDHZlOHIWuUWPehaScorflB4q6i8rRYccnm+jMK6VSB1kI9r+loCC3eF5dHb2nk/XEcucLmdC+N+V5Zg6Teq6vQ3FeNX3VRBTsN29gctb64X1XtBo9bg8Zawh41HbdfbZ/7iKob4dhshlvtrJBHfRhlFIuN7y9pJzupsvBxRRon9hPFcGw6TdZTyt8V9bymcYqAfatp3zC7eVw51nfxOLTa5aN9d6xUwxafKR4rea3VZ5cwJFtJ39n8IyWdbFcFZQ76ULRwqU6/WLPkJfFkpGapyBldTMDqIuLr+qdKk6SkpCTY/vc2W018fD4fZs2ahU8//RTvvPNOzVsoCIIgCIJQD1RpkjR//vwKf6+Mb7/9FmeeeWb1WyUIgiAIJzm1oUmydr0umFFtTRIA/PLLL7DZbGjWrJlyvH379li/fn2NGlYv2Gzh9W82cdjLNB/+prCJitdMbWSCsXIxYKfwCNo2fl46N4PNaxZbhXkZnftC2/JOW/adJWr+0kZq/vh91Lwgm8uofjJZOC1MFFpIGbaE8qOllXRfMplGfeSSQHMxYF4+91fAa741m8uPNLHltyLzWlNqPJlYnLnqwDaJvAAA8Ceq18fsp5Axu9WbcxWq9bO7BKv3xlmkmjzsuWRO08zWZNukZ629t2wapvawOQyG+Vi3dJHg5sFGzz6GxpLm8oDcTbiP5XdRiBTNbOtm1xn0nliEG9JcY/B7zt84/lts8LOyMNtTe0obqM+2sI9qPhvbSg0z0thRCDPYKaODXky3Te3PRJv60Q1F3K/LbhE2qpaoFeF2LbXlZCVqZ5KhUAiTJk1CUlISMjIy0LJlSyQnJ+Oxxx5D6H/6AofDga5du9Z6YwVBEARBEI4XUU+SJkyYgBkzZuAf//gHvvzyS3zxxReYPHkyXnjhBTz88MN10UZBEARBOOkoD0tSk5/qCr9nzpyJ1q1bw+v1okePHvjkk08qzZuVlYVrrrkG7du3h91ux5gxY7Q8r7zyCs455xw0aNAADRo0wMCBA7Fp0yYlz8SJE2Gz2ZSftLS06t1ALRH1JGnhwoWYM2cO7rzzTpx++uno2rUrRo4ciVdeeQULFiyogyYKgiAIwslHfYUlWbZsGcaMGYMJEybgyy+/xDnnnIMhQ4Zgz549Feb3+Xxo3LgxJkyYUKkVac2aNbj66qvx0UcfYcOGDWjZsiUGDx6MfftUvUWnTp2QlZUV/vnmm2+qdxO1RNSapMOHD+O0007Tjp922mk4fPhwrTSqvjDstrCd3Wrbtraln/fyauEHzMMZBL2q/d3OWg4LIkOJaG2xmgpzfs0lgPnlmjaBCLrNy3OwiwDqO3ceaS9Ys2Sh+bHSarCWwp1vvu+a67caK6x7iQwrUtH1XH5RUwot0vTY74EEtW/sxeZb+llDw3AYkNhf1euTf1a3RbPejLed21g7R64ybOBnyeF4zMN0aO+hpnNRL/AcJBcC3D4qj10I8NhhXQ277tDHhpp2hcx1Ptr9RySDXg7poqbZnYAWCknTZ5m7HdHckvAnj18r7TUy1+IVtFT7uuT0EiU9vJO66tDNsxdm7AuqO7ELgqp/BnYBEKQPwSGOuWOSt66oL2eS06ZNw4gRI3DLLbcAAKZPn44PPvgAL730EqZMmaLlb9WqFZ577jkAwLx58yos8/XXX1fSr7zyCv71r39h9erVGD58ePi40+ms99WjSKJeSeratStmzJihHZ8xY4bokARBEAThBCMYDCI/P1/58fl8Feb1+/3YvHkzBg8erBwfPHhwrW7IKi4uRllZGVJSUpTjO3bsQHp6Olq3bo2rrroKP//8cyUlHB+iXkmaOnUqLrjgAqxatQp9+vSBzWbD+vXrsXfvXqxYsaIu2igIgiAIJx214gIAwMaNGzUfh4888ggmTpyo5T148CCCwSBSU1OV46mpqcjOztbyV5e//e1vaNasGQYOHBg+1qtXL7z66qs49dRTsX//fjz++OPo27cvtm3bhoYNG5qUVndEPUnq168ffvjhB7z44ov4/vvvYRgGhg0bhpEjRyI9Pd26AEEQBEEQLDFQO1v4e/fujffee0855vF4TK+xsSnbMLRj1WXq1KlYsmQJ1qxZA6/3mFlzyJAh4d+7dOmCPn36oE2bNli4cCHGjh1bK3VHS1STpLKyMgwePBgvv/wynnjiibpqU/0RqXRjxRv7FGFDpUVoD1sZayfYNxEVH2CDvoXuJaJ+Kx2I5lNJ829SeciTitKsrwqxbx72a1RkHkqjwQ713sviSBdCuhkP+dJhrQXrRlgjxf+olcWRtoPCnGihJVjzxPWRdoTzszajKI3SLdnX0LHrnQVq3zhVGQdsFGWD+86pup5B3K9q22IPkt+jUnO/RdHCmiEbjfuQm2O8mJen6c24vhC/1+bnHeS3yUH9yz7BWMMU1PRv1F+s4bL0I3WswexbjcexNi49Vn1jXreW3yIcEeup+L3Iz1Db02aIalbhMCNx5LeoNZUXYr2XLVdJF9hVp2AJ5HzuSMh80lAW4TyvzDheYUlqw0+SDQ6HA4mJidaZATRq1AgOh0NbNcrJydFWl6rD008/jcmTJ2PVqlU4/fTTTfPGxcWhS5cu2LFjR43rrS5RaZJcLhe2bt1aa7NJQRAEQRBOHNxuN3r06IHMzEzleGZmJvr27Vujsp966ik89thjeP/999GzZ0/L/D6fD9999x2aNm1qmbeuiFq4PXz4cMydO7cu2iIIgiAIQjlGLf1EydixYzFnzhzMmzcP3333He69917s2bMHd9xxBwBg/Pjxyo40ANiyZQu2bNmCwsJCHDhwAFu2bMG3334bPj916lQ89NBDmDdvHlq1aoXs7GxkZ2ejsPCYp/Rx48Zh7dq12LlzJz777DNcdtllyM/Pxw033BD9TdQSUWuS/H4/5syZg8zMTPTs2RNxcXHK+WnTptVa4447dlt4m6se0ZpNJhwKg9aqtaVrWlYns4KT0ryMbznQI7IbWjwByhvtQmANw1A7itWl6UCseST2vAz1fAmt8Mb9oqZjDqg2pSCFegiQmYFDzjDOEvOwJxw2hLdeszmPzZH+eNrST1I+X2PqECeZEQ4fM+m4KKxIiKN00C5mj7rrGYl7KaxIgdqXHIldc79AA1MLUcNb/mkscd9YuW/gsRiMUe2H/CzYvMXmwgpeVPVySrN5kc2FdtowZPep9bE5jvuT79/UXMeuKKiv2Bxm95u/x2zyZ3cK3JagW83PZmgHh14iFwBs+s31qVv0NxW1UdJ94lSTy+GQagpNtqsvdmun2kA7Pc1c6q8gyPzGL089YKB2hNvRcuWVV+LQoUOYNGkSsrKy0LlzZ6xYsQIZGRkAjjqPZJ9J3bt3D/++efNmLF68GBkZGdi1axeAo84p/X4/LrvsMuW6SAH5L7/8gquvvhoHDx5E48aN0bt3b2zcuDFcb30Q9SRp69atOOOMMwAAP/zwg3JOzHCCIAiC8Ntn5MiRGDlyZIXnKnIcbVj8M10+WTJj6dKlVWnacSXqSdJHH31knUkQBEEQhBpRE6/ZkWUI1SfqSVIke/fuhc1mQ/PmzWurPYIgCIIgAECt+EkSC09NiHqSFAgE8Oijj+L5558PC67i4+Nx991345FHHoHL5bIo4cQl4HUArqOaAd4abQuSloGlDKxhIm0Iw+Eb2P5vOf3XwqCY5LeQ52uhILQt/+bXa+4PWF9FOgwH6Tb4G5DfVm1P8nY1Q3yWqpvRttyTZog1SFbfHIelToR1Ker1rOMpbkIapGZq/mAs69vU864DFLImor4g7VrmLeqxOWo6/le17zh0hRZOh11faGFDeBs66bE07Z65xojLs5XRWCL3FRzOx5+opgMxantcRep51mA5KBwQa4609oUsttWzbshvroGy+ynMjJ9Dj0S0n6rmsCPaODfMNUusGeJvlJ1cewS8fO/8HVHPsv4s+Sc1nZ+v7mBa3FBNL2h2tpJOS1e3+J/ZWNXIDEzepp73qC+Dh/wtNLarzybBpgr+fBE3VOiI0l9CdTFs1h8syzJqpyknK1FPku666y4sX74cU6dORZ8+fQAAGzZswMSJE3Hw4EHMmjWr1hspCIIgCIJwvIl6krRkyRIsXbpU8Yx5+umno2XLlrjqqqtkkiQIgiAItUBtaJKEmhH1JMnr9aJVq1ba8VatWsHtdusXCIIgCIIQPbUVl0SoNlFPkkaNGoXHHnsM8+fPD8d+8fl8eOKJJ3DXXXfVegOPJ4bDdkx/YjV9Zw0S61jc7A+FQ0uY25nZfs/+ZbT2RRav+XhiXzcW9nSLtmk+pAhNb0W6ELcqJYBB+q3kH839FDFl8RS2xG1x/5ruRk1r2g7S/WihPqi+/Aw1XZLGuha6v0JzzRa3L7K/nOQnKX6fWnbMQbWxmp8jC/0Vf6A1DRLpwVhzw36CNH9iVlB7AvHsF8lcL1YWS9dT/pBT/QS68ygMS5nFu2Dhk8wWZawPOwmN+F11lB57IJpPKdJraT6r7OaaJU1/pvmYUtvipfdc+wayzpKSzmLSAP2iZmA9XfBn8p8W30RJr0pW0+82PkNJx7QoUNJnpu9V0gMbqBqmbl7VIVt6xHvnsdCc1ha1EpZEJlk1IupJ0pdffonVq1ejefPm6Nq1KwDgq6++gt/vx4ABAzBs2LBw3rfeeqv2WioIgiAIgnAciXqSlJycjL/85S/KsRYtWtRagwRBEARBgJjbTgCiniTNnz+/LtpxQuDwh+AoNwfQUjNvPbb5yObCWJnH2AQUMjcRafAqvtlOZCt3AdF6SrfIbwupJgtXvuru3+FXtWsc3oC39PMW+vh95n1v18IhqOf16OTqebaQsBmiLE69vrCFmi5tYr6l316sNshJ2/b52bILA29EaJH4fRRWpJC2kAfMzT1sxmVTadRo5VFf8JZ/Hkv8bMhszc+Sn7WriMx9QfNI9Gye8yep9TlLOEyKWr9moqIkh7jRXCAQurmzcvOnbjo1j0yvjXsXm6ktfIVoz9bivN/clKvdK7tLUKOOwFlKZvsCKk8NWo/Qz/RstyUp6c0JavqT9E5q/c1UPzBntjzmYqCsyA9gIeqa2jC31diFwElO1AFuBUEQBEEQTgZq5HFbEARBEIQ6Qsxt9Y5MkgRBEAThhMQGCStSv8gkKQJ7WQh246joQHPRbxGOwUb7yjmcAsP5rbbVa0RhKNXDjJjXFXJZxTEx7xtNpwHW9KhnnbTl3U7SCneBen3IxfdDtXG4Bg5TwroW0lbYSUtRlKZeUKxGS0AggbZpk47FUWre36zt4PZ49qvpyNAiWlgRgp+97kqCL7D6t9Ui9IWFxshg2YymU6Ft7Np7qF5uuLivecu8eX4OrRHw8tgi/RhtW+dnx+WHAur1rBHT3xVzIrfV87Ws39LeS67bwWOBvkn8HWA9Fg891nFqYVEoO987ux7hpDY2WXtI7iiofIdPPR9zSEkiLpvcR3yvfqi+SeoQ/j3oo4FVV9TGSpKsRNWIKv2pTUlJwcGDBwEAN998MwoKCiyuEARBEARB+G1TpUmS3+9Hfn4+AGDhwoUoLT1Os2hBEARBOFkxauFHqBFVMrf16dMHl156KXr06AHDMHDPPfcgJiamwrzz5s2r1QYKgiAIwkmJgVrYwi+apppQpUnSokWL8Oyzz+Knn36CzWZDXl7e73I1yRY0wlqhkIe0EeTHyKbpeqKcslv5UaoJ7K+ET2u2f3NdCGt6nCUUasIitEVJ01glXdRB9ZsUv011lOTwsQZJba6VToX9GLEGiX3XcHkFLdULilqqFYQSSFhTTFqQgLkfJn4grnw1HZ+lts97UHUYo2gtLKJeaH6QWMfC/r8shiE/W9Z96PowC00UYSf/YyGXOjasrtdC8hD898ZB+jP2u6S1j87z/WuPQ3N7pAltKM0hcTi8UaSjJKqLNUUchsRCa6jpvdink4WmyFHKz478MLFey20+9rSxyGluH/s7MwnnUxHuQvK5pbpJgvfIsfYHLDSntUVtBLiVsCQ1o0qTpNTUVPzjH/8AALRu3RqvvfYaGjZsWKcNEwRBEARBqE+i3t22c+fOumiHIAiCIAiRiK6o3qmWx+21a9fioosuQtu2bdGuXTtcfPHF+OSTT2q7bYIgCIJw8mLYauGnvm/it03UK0mLFi3CTTfdhGHDhuGee+6BYRhYv349BgwYgAULFuCaa66pi3YeFwy77Zgdn+z9mu8gMvTaWbPE9m9Nu2Hua6hW4bo1zZH5XJk1SKwbCcSpupFQvDqs8lqrnZGQorqQ8Ceq15cmq+1xkW8a1hixbxs9vpea9ieqGUoaqedLmpGYgWUkher92Mn/StDL8brU6+N+UfMn7lHrcxaR5ovlDxFpK82RHqeOdCDs/4v1aoSdtBic1vL71Xux8gemxUhkXz8cD4x1N5TWfWSZx3LTdDFUv1aexf2E6LzNzs/LQrPF3Rsx9HRtoWlTKojhSKc5Fhy/R1qsOPNvlvbs+BtJcQLtAX62XCDH0yR9nDY26HKWWHH5FhooR8SzMCy0a8Lvh6gnSU888QSmTp2Ke++9N3xs9OjRmDZtGh577LHf9CRJEARBEE4UbIb1ZgrLMmqnKSctUZvbfv75Z1x00UXa8Ysvvlj0SoIgCIJQm4ivpHol6pWkFi1aYPXq1Wjbtq1yfPXq1WjRokWtNaxeiNhvqS2zO3nt2WKpm81n2tKu+bK6bnbgmACV/3+ghaKgwjUTASWdxWSforYGY9Q9+bzsze4THBR2JPfXBPX6Zmp9hk0tPy6LyiulZXzNbKCmi1PV9mlb+r0cKoL6z8/L+ub9x+cT6X+HyLAiAODwUf08drRwEJV/9bQt9xSKgk2tUf+byea9gLk7CO1yu3n9bPrVwv8E+UUxb5+1+Y2ut9jDr5m4uD+stq1zGBU227BJy8T8x6ZOzb0AKwQsQi2x+YvdI2jlE7zl3wqtfs0tCj07HjpsntPGEr233NcW98NEll9j10XRVCp+kuqVqCdJ9913H+655x5s2bIFffv2hc1mw7p167BgwQI899xzddFGQRAEQRCE407Uk6Q777wTaWlpeOaZZ/DPf/4TANChQwcsW7YMl1xySa03UBAEQRBOSsRcVu9EPUkCgKFDh2Lo0KG13RZBEARBEMqpjUnSST7JevTRRzFq1Cg0atTIOnMFVGuS9LvFZgvbqa22QrN9nnU+rIvRtA4WknkrDZIe3sAkL1XGW/gNp7mWgDVIrBvRtjmT7T8u2zw+QH4btTx/QzU/a5zi9qn1uQrU+kobqecLT1HLcySrYVGMfPX+nEfU9hlO863F7jy1voTdav74X1lzpV5vqUFiHY5y0kIzwwPNIpoO60I0TY+b3B+wLoaGkq57ofxu87FnGcaEXRBYhEUJqt4mNKxCV2h/cCy21UcrJ7GxSwLWKCmvLum3onQBYNV32r1w2wLmmiL+Rtn52bN20uJ6XcNE7dNC5pifj5ZIFwhaOJ66QlaSqkx+fr52zDAMPPHEExgyZAjc7qMvf2JiYlTlyiRJEARBEITfNA0aNKjwuGEY6NOnDwzDgM1mQzDIKxjmyCRJEARBEE5EamN320myEtW0aVN069YN9913H+z/20VrGAYGDhyIOXPmoHXr1tUqVyZJgiAIgnACUhvOJE8Wvv76a4wYMQKPPfYYXnvtNTRr1gwAYLPZcNZZZ6Fjx47VKrfakyS/34+dO3eiTZs2cDp//3MtzeeGKuupIESAuQt9TTvhttALEGy/V/w4sRaANC22MgoVQZqkYIz6PE31T9BfYtYeOOheHKVq2lmq1lfUVG1PaSO1gryOaud7f1Wv9yeTtsGl1hcsUDVI9iISotjNv0qxv3JYEbV8dz6HFTEPv2CF2UfSoH8TOYSJFnZEkyxZhC0h7QWHGdHLN9fOcVgOzS8S+/Kx8EPE989+mFg74vBziBvzMCXWoT7UZIg1TVwcrfRb+W3ikDqRspoQl82fDE3jw3WzIyVuKz171p9Z6Dat9GQaVn6T+Ia1+ugAv2dOHpvqaaswKJF+mkIWbRGOPykpKVi+fDleeuklnHXWWXj66adx9dVX17jcqD1uFxcXY8SIEYiNjUWnTp2wZ88eAMA999yDf/zjHzVukCAIgiAIqFdv2zNnzkTr1q3h9XrRo0cP0yD2WVlZuOaaa9C+fXvY7XaMGTOmwnxvvvkmOnbsCI/Hg44dO2L58uU1qrci7rzzTmRmZuLJJ5+slTBpUU+Sxo8fj6+++gpr1qyB1+sNHx84cCCWLVtW4wYJgiAIglB/LFu2DGPGjMGECRPw5Zdf4pxzzsGQIUPCiyKMz+dD48aNMWHCBHTt2rXCPBs2bMCVV16J66+/Hl999RWuv/56XHHFFfjss8+qXW9ldOzYEZs2bUJaWho6d+6MmJiYqK6PxGYY0a2JZmRkYNmyZejduzcSEhLw1Vdf4ZRTTsGPP/6IM844o8JteFVhypQpePDBBzF69GhMnz4dwFHR1aOPPorZs2cjNzcXvXr1wosvvohOnTqFr/P5fBg3bhyWLFmCkpISDBgwADNnzkTz5s2rXHd+fj6SkpLQr+/DcDqPTvyCHnXdnJfhnaVksqKlWUcp2+PUpGYuo6VvK3Mbh2uI3N6qhYbgZXeODE/3qoe2MB8iejgBNRlyk8sA3kpMt+pPUNuTd4p6fVFHNc6Jjbbwa9G7S6ivaEu/LWDuviFhF6X3qjYQNulo/cdmCw4VYhJmBLAwt/Gqv7YlnW2h5uYwNgs7StRxbGVyYXcFlmFIaOzxe8d95/CpD8dO7QuRqZjNh7p5S00H4uhdsDAth2jo6S4CYIruDsIirWxDV8+xGddGz0ory+LTr4dgsbje/JMVtfnNKgyKFnbFQhbA96O9OxYuAgKeY+cDZaXY9M7DyMvLi3pLeVUo/5uU8Y/HYK/BH3gAOPSv5bi9d19MnTq1ytf06tULZ5xxBl566aXwsQ4dOuDSSy/FlClTTK/t378/unXrFv47Xs6VV16J/Px8vPfee+Fjf/rTn9CgQQMsWbKkxvXWFVGvJB04cABNmjTRjhcVFcEWZSyccj7//HPMnj0bp59+unJ86tSpmDZtGmbMmIHPP/8caWlpGDRoEAoKCsJ5xowZg+XLl2Pp0qVYt24dCgsLceGFF0a9zU8QBEEQfo8Eg0Hk5+crPz6fr8K8fr8fmzdvxuDBg5XjgwcPxvr166vdhg0bNmhlnn/++eEya6veHTt2YOHChXjyyScxdepUvPrqq9ixY0e12x31JOnMM8/Ef/7zn3C6fGL0yiuvoE+fPlE3oLCwENdeey1eeeUVxc+BYRiYPn06JkyYgGHDhqFz585YuHAhiouLsXjxYgBAXl4e5s6di2eeeQYDBw5E9+7dsWjRInzzzTdYtWpV1G0RBEEQhBOGchcANfkBsHHjRiQlJSk/la3MHDx4EMFgEKmpqcrx1NRUZGdnV/tWsrOzTcusab15eXm45JJL0L59e4wZMwbz5s3DnDlzMHr0aJx22mm49NJLq2XpinqSNGXKFEyYMAF33nknAoEAnnvuOQwaNAgLFizAE088EXUDRo0ahQsuuAADBw5Uju/cuRPZ2dnKrNLj8aBfv37hWeXmzZtRVlam5ElPT0fnzp1NZ54+n0+bVQuCIAjCCUVtCLcNoHfv3sjLy1N+xo8fb1o1W4bKnTHWhKqUWd167777buzcuRMbNmxAbm4utm/fjh9++AG5ublYv349du7cibvvvjvqNke9d79v37749NNP8fTTT6NNmzZYuXIlzjjjDGzYsAFdunSJqqylS5fiiy++wOeff66dK585VjSr3L17dziP2+3WPG1azTynTJmCRx991LRtrL2wBc3t8/YAb6unrdSsMeKtzXzaRHNUUXmR2/w5dISW5rZZbBO3WYVQ8VtcT+U7/OZaBne+er7BDgqF4fco6ZI09fpgDD879bzDR/qyIvV8XJZaf2wO6XL85uILu8H1W2gxrLQaNfkwWW3TpmcT0jRE0V0fbVu1UBEW+jnWLGn5LVwIOIvVwcDuLpzkniJouUXf/DyjhT2xCL3B5UXenx7Gg8q26AurnU/a2LAIvWQV9sOARXssNE2aBonvj8ci35/VUGVtIZ13RWgXObxOnVFLYUkcDkeVtVONGjWCw+HQ/obm5ORof4+jIS0tzbTMmtb7zjvv4IMPPkCvXr20c7169cLLL7+MP/3pT1G3O+qVJADo0qULFi5ciK1bt+Lbb7/FokWLop4g7d27F6NHj8aiRYuUXXJMdWaVVnnGjx+vzKj37t0bVdsFQRAE4feI2+1Gjx49kJmZqRzPzMxE3759q11unz59tDJXrlwZLrM26jX7u1/dVbCoV5IcDgeysrI08fahQ4fQpEmTKgumN2/ejJycHPTo0SN8LBgM4uOPP8aMGTOwfft2AEdXi5o2bRrOEzmrTEtLg9/vR25urrKalJOTY9qpHo8HHo+n0vOCIAiCUN/Uisftalw/duxYXH/99ejZsyf69OmD2bNnY8+ePbjjjjsAHF1o2LdvH1599dXwNVu2bAFwVGd84MABbNmyBW63O+zpevTo0Tj33HPx5JNP4pJLLsHbb7+NVatWYd26dVWu14yLLroIt956K+bOnYuePXsq5/773//ijjvuwMUXXxx1X0Q9SarMY4DP5wtH2a0KAwYMwDfffKMcu+mmm3DaaafhgQcewCmnnIK0tDRkZmaie/fuAI6q39euXYsnn3wSANCjRw+4XC5kZmbiiiuuAHDUqdXWrVuj2u4oCIIgCCcctWRui5Yrr7wShw4dwqRJk5CVlYXOnTtjxYoVyMjIAHD07yz7Lir/Ow0cXQRZvHgxMjIysGvXLgBHpTpLly7FQw89hIcffhht2rTBsmXLFPOYVb1mvPDCC7j66qtx1llnITk5GU2aNIHNZsP+/ftx5MgR/OlPf8Lzzz8fdV9UeZJUXrjNZsOcOXMQHx8fPle+AnTaaadVueKEhAR07txZORYXF4eGDRuGj48ZMwaTJ09Gu3bt0K5dO0yePBmxsbFhL5pJSUkYMWIE7rvvPjRs2BApKSkYN24cunTpognBo0ULJcEaoBK/egFpOQJx5ECFfQPR5YymQSJ7uZmfJdYcWfkH4f9UNNc7XLeFHybuCy0/6y5If8V+h5xF6upk8s90nsKaFDdVy/M1VK/37leFIUk71WfrPUixIAhdh0MZLMI7WGGla6kJVroRV775wLTyRcPoGhsam+xfzEd+lui9CZI/sVCSm86bl+csIn0c+TvT/JPFsL6PHw7rdui05reKzjvMtYkaEdl1v0eUtvC/xRojfu9YI2TXHKBRgfzXRPMpxRoiKydS/A3mvrJ4r6zeIytNluYX6tgNa77OfoeMHDkSI0eOrPDcggULtGNVcbl42WWX4bLLLqt2vWYkJyfjvffew3fffYcNGzZg//79AI5anPr06RPV/CSSKk+Snn32WQBHO2LWrFlwOI59DdxuN1q1aoVZs2ZVqxGVcf/996OkpAQjR44MO5NcuXIlEhISlHY5nU5cccUVYWeSCxYsUNonCIIgCL856mkl6bdMkyZNcPPNNwM4qn1+5ZVX8O233+Liiy/GOeecE3V5VZ4k7dy5EwBw3nnn4a233tJ2lNUGa9asUdI2mw0TJ07ExIkTK73G6/XihRdewAsvvFDr7REEQRCEeqOeNEm/Rb755htcdNFF2Lt3L9q1a4elS5fiT3/6E4qKimC32/Hss8/iX//6Fy699NKoyo1ak/TRRx9Fe8lvBlsgBFv5GjIvtfLyapRbo9klAC/W6uEeyGRF0dcN2tYf9B57lFbmGl5WtzLlWZnb2IRjuTXXqu942Z/6zkHbtOP282YBdnmgpgPxavlBD7VfC5tC7dGio1tt20ZUaO4g7Cbb3Gvot4TdGWjbvl3sLoIKsIjcrpnn6Lwrv2Kvv+HsbIrl94hNyxxWhMZmIFb95PG7wCFztG30fL/07O38LtjMyze0UPT8rlFzgpHnzM3YPDYMyz3w5n9NdTM7nef3gN0bsHcJbj71DbsuMRz8YqhJNq1GizZ26dmHItIhzd9CHRHhELL6HKe21jP3338/unTpgkWLFmHRokW48MIL8ec//xlz5swBcNSP0j/+8Y+6nyQBwC+//IJ33nkHe/bsgd+vahimTZtWnSIFQRAEQRCqxeeff44PP/wQp59+Orp164bZs2dj5MiRsP9vweHuu+9G7969oy436knS6tWrcfHFF6N169bYvn07OnfujF27dsEwDJxxxhlRN0AQBEEQhEoQc1uVOHz4MNLSjnoWjo+PR1xcHFJSUsLnGzRooMR9rSpR76MZP3487rvvPmzduhVerxdvvvkm9u7di379+uHyyy+PugGCIAiCIOiU+0mq0U9938RxxCrESXWIeiXpu+++w5IlS45e7HSipKQE8fHxmDRpEi655BLceeedNW5UfWH3BWAP/G/7N29V5q3TbB7XwgtQdt5u62Ntgyo+sJEWoyxZdX6p6YYi0pr7f5ZTaRojc10Ko+k2+N4tbPva1FwLyUJaANo6HPDytmz1vIfCmuAX9Xz+Kerp3NNom7lbdd+Q9BPpZuh+gh52eUD9qYVHsNCGhHjvtXl/m5XNWjgrjRBrgKzGCufX/mu1chFgpfWjvtDC8WiuMiz6juCxVBZPOhi+ParPVWQegobdV/C7FfSytpArjGIZINoVA3Yjwn3J76kanQc2rtDi2esuC1jbx+2jC/i7wPouTvM3N2ChLWRpo4mnjxqLqatKbexuO0lWkgDgxhtvDDuKLi0txR133IG4uDgAR305VoeoJ0lxcXHhytLT0/HTTz+hU6dOAI5G8RUEQRAEQTie3HDDDUr6uuuu0/IMHz486nKjniT17t0bn376KTp27IgLLrgA9913H7755hu89dZb1RJFCYIgCIKgUythSU4S5s+fXyflRj1JmjZtGgoLCwEAEydORGFhIZYtW4a2bduGHU4KgiAIglBDxJlkvRP1JOmUU44JOmJjYzFz5sxabVB9YgsaYTs7+zexEldofos8alrzR0PaipBHfRTsn4a1Eew/RTnHsgzWfXDIFbLVs62fu0LTrbCGSQu9UGlTj9ZHmqMghYLwJ9gpba65cpSqDfDmUmiKbaRRaq1ef6irer0/waukG/yoijMcxezMhrQRmi8hNbsWJiYaraEWQ8bcZ5XdR2E42P8Wa4ysqteevblPLcvySJun3Y+LBhPV56D70/RwhNPiNecwJKXJaoayxtweNekoU8/HHFDHDvcPfyfMNFWa+xzWTXKIFU03Se893avBbeP6rQRnFn1rdT37sGJ5lqPMXPvH98Mha0h2iqDFdy9SwxSyCqki/G6olp8k4Giw2ZycHIRIWNmyZcsaN0oQBEEQTnpEuF3vRD1J+uGHHzBixAisX79eOW4YBmw2G4JBkyUOQRAEQRCqRG1okmTNq2ZEPUm66aab4HQ68e6776Jp06a14ofgRMFw2o+ZG6zui86XxZO5jLaFOwupLgqPoJloeDuuFg6CmhOxFq25B7DY0q+FzeAlfouwJVZb2jlyO2/VDdC250AsnY/hNDVXC1xvFTJGTcfvVdOF1CH5p6oT/8gQMADQaKt6vStPbRCbsPRna7VtH1VGc5/AYTJi1LZrkc6jDHXB8PVsRubwOlbmNTYh2dg9gkXkem0bO4f7IZcBHB5Ic3dhqO4hShuQmZ3cUZQ2UNP+ePV6VzG5DCBTMZuOHRGhPzgcjpW7AH7P2cxu4y3yfD2bha3+eEf5p8HqvbB0h2BiHgN085p2v5q5jk29xwoIRmmWFn67RD1J2rJlCzZv3ozTTjutLtojCIIgCIJwQhD1JKljx47iD0kQBEEQ6hrRJNU7Ua8ZPvnkk7j//vuxZs0aHDp0CPn5+cqPIAiCIAg1pzbCkgg1I+qVpIEDBwIABgwYoBz/PQi3DbsNxv8M11qYEIPt07TFn7ersnTCy1oItTwHb/1lbQX9O2AWSkTTLxFaiBUtVAUlWS+lxcdR83OoBR/pNvzxLA6ovK1H61fTdgqPwOEEgm41XRbHYUTU884SNe2muX6A2lvUQXVv709SC2yyWc3vPahqlHhrsuYewkoHFJHUwoxwiBfS1ISoLx1071YyEu3Zk3sJ1lOxKws7669CtIWet/xzfVbfFy2MCJXPY5+wBchFAg0+z2H1WboKzMOK+BMp7AmNRdbb+eNpmzrdrrPkWP+5C9S+dBXSN4v1WvyaW+jLNK0ii5Iswu1Y/YHW3ZpYXMDVa+F6zC+3+y3cVfB3k/V8EWNXC3FSV8hKUr0T9STpo48+qot2CIIgCIIgnFBEPUnq169fXbRDEARBEIRIxON2vVOlSdLXX3+Nzp07w2634+uvvzbNe/rpp9dKwwRBEAThZEZ0RfVPlSZJ3bp1Q3Z2Npo0aYJu3brBZrPBqMBnxW9dkxSJQWFFWHuhwRokcoHvKjL3x8L6AC2UiFW4hyheJM0vj4uFHFSYhQ8nDitSmqL2XUkjCg9AmiAH+TnikCta2BFVEqT7N6HyfclqOhijXlDmV9sfu1/Nn/KNmi5ppFZQ1FJt4KHO6v2mfKuKpGIOkB8l9sVDmit+HpG6Hx43zmL1YldeqXoth/Vg+Nlb6DSYkNs8bIiukVL9BrHWTvODpOmzzDVMmkbJRN8FVKBL4VeBQ2GwL54A+UejkDVB8p/G/tQClNb1dMfSxU3om9FAvVbzwVSitt1Ran4vWugjra/Nz3Pf8XfHKvKTVUgZLbyPHjeF0jQWrTRN3N7I36MMtyP8dqnSJGnnzp1o3Lhx+HdBEARBEOoYEW7XO1WaJGVkZFT4uyAIgiAIdYOEJal/qjRJeuedd6pc4MUXX1ztxgiCIAiC8D9kJaneqdIk6dJLL1XSrEmKjN/2W9Yk2YIh2PC/9rOBm2zQwUS164rTVG0F+z9h3Y7niKod0XzlaJqj6OKxKZdGG1/Pzm0nHQXpSnzJpEFqSLqKeGqPhXaApQJOVVaju2shGUzQS+kY875yFahpB9WnxY6LVc/bQqTJaqQ+y6w/qPmTtqsNTNmuiqx0LUbluhtNI0Ox0bTYaaz5MYkBWBEhjn3GGQzW6JAOhH3PaO5s2ZETFx+d/1tdB8O6FBrbbvPyQ1Y6HD5N/e0qpNhwPrU+B9XvLK087p8viXwykY8l7uuyGLUzuWwtbhx/kyxinWkaIfNhrI1zS40RF2ehH9OePee3dApWzXPC74oqfXFCoVD4Z+XKlejWrRvee+89HDlyBHl5eVixYgXOOOMMvP/++3XdXkEQBEE4OTBq4UeoEVH7SRozZgxmzZqFP/zh2L/H559/PmJjY3Hbbbfhu+++q9UGCoIgCMLJSK24AJCJUo2IepL0008/ISkpSTuelJSEXbt21Uab6g+bLbx8rpmovGpX+Rqo5jVe+nYVqSOTTTYOv7r07faRmdLCTKBt1VYyW2xt5a28tOwdJPcHkduOAaAsTr1XXzJt8SdzFy+bu4qoObzlny22Flv8y+LUNNfvKqSt0uRCwE3mNnZRwC4EAvFkliihbfgUcsafot5QXnte91crTNyjmmKdJer1Sn+yCYPdOTDaFnnqXOp7fcu8ubmMTRpaCBxujsUWf808x2FKLEw8fJ7r09rPYVa4/Q4a62ye08xvFL7Iz9vw1WfN5jm7v/Ln6SyikCmx7D6A0tp5eu8pnA+b4xjNdUeI3wt2e8KmV1CaxyaHwLF4dtGGY4oWWyW/1zUyyalXog5we+aZZ2LMmDHIysoKH8vOzsZ9992Hs846q1YbJwiCIAiCUF9EPUmaO3cucnJykJGRgbZt26Jt27Zo2bIlsrKyMHfu3LpooyAIgiCcfIgmqd6J2tzWrl07fPXVV1i1ahW+//57GIaBjh07YuDAgcouN0EQBEEQqk+t+EmSiVKNiGqSFAgE4PV6sWXLFgwePBiDBw+uq3bVCyGXAyHn0S7RwidwmBKyf8ceUA84yeU/b5sPkT2+LFHVOLkKyUUAa5ZYfBFpvydtAIeKCHrVNBelhUqIYe0C3YvFKHIVqmlniZrWtAX0Ugdi1LSfJHGaBimf0sVqOkT1cXnsskCD9oEHvWqDXQXq+fidan/z/ZQ2VNMOv9qhibtJ2xGpq7Ha9mylsSE0DRLnZy2chUaJsdq2baX1sNxmzsWzpslKIxWyCj9ELg4sdDaaZozb41Q7zE4uHAzW4UR8R7irWQfJYUdcpGHiECkMv9esuwypnyzYKZyO54h6r+5C8763+3ns0r1zX9I31eaPcmxauDAwc7MSjQsW4bdNVOY2p9OJjIyM37QvJEEQBEH4TVCP5raZM2eidevW8Hq96NGjBz755BPT/GvXrkWPHj3g9XpxyimnYNasWcr5/v37w2azaT8XXHBBOM/EiRO182lpadW/iVogak3SQw89hPHjx+Pw4cN10R5BEARBEHDM3FaTn+pMlJYtW4YxY8ZgwoQJ+PLLL3HOOedgyJAh2LNnT4X5d+7ciT//+c8455xz8OWXX+LBBx/EPffcgzfffDOc56233kJWVlb4Z+vWrXA4HLj88suVsjp16qTk++abb7i640rUmqTnn38eP/74I9LT05GRkYG4OHX/9RdffFFrjRMEQRCEk5Z6El9PmzYNI0aMwC233AIAmD59Oj744AO89NJLmDJlipZ/1qxZaNmyJaZPnw4A6NChA/773//i6aefxl/+8hcAQEpKinLN0qVLERsbq02SnE5nva8eRRL1JIlDlPye8DX0IOg66rNGs9eTFsNBWgRXAWkJSHvA9npOs72dfRXpfpPU05H+X9hXDodaYFu+P4HyO1iDpNbFOgure3P42L+JuR8nrs9Kg+QgjZO9TE0HKH9ZAp0nv0f2UvZppeZnrQZrkLyHQGkqn7QWrPUobE7ti1U7JC7rmNbEVaiOO0cJ3TyHs7Hyg1RDtNAVVmE87Oa6ESvNUbTw/WoaJQuNFF/Pfo6swpRYabY4BBBruFQ/T6R7dJl/zvk9tBns1Irawpofyu+PNw8/VJSqni9uQmFQSCvozSUfUn5zP0vc3qCX9V3m98fPVvPZRdT2WDyeBINB5OerYk2PxwOPx6Pl9fv92Lx5M/72t78pxwcPHoz169dXWP6GDRs0jfL555+PuXPnoqysDC6XS7tm7ty5uOqqq7SFlh07diA9PR0ejwe9evXC5MmTccopp1TpPuuCqCdJjzzySF20QxAEQRCESGppJWnjxo2aE+hHHnkEEydO1PIePHgQwWAQqampyvHU1FRkZ2dXWH52dnaF+QOBAA4ePIimTZsq5zZt2oStW7dqboN69eqFV199Faeeeir279+Pxx9/HH379sW2bdvQsCHtcDlORD1JKmfz5s347rvvYLPZ0LFjR3Tv3r022yUIgiAIJzU21Ny5tw1A79698d577ynHK1pFUq7jVVfDMHXzU1H+io4DR1eROnfurDmgHjJkSPj3Ll26oE+fPmjTpg0WLlyIsWPHmra3roh6kpSTk4OrrroKa9asQXJyMgzDQF5eHs477zwsXboUjRs3rot2Hnd4WZzDD9g5mnqUy+xWEak5fyBBXa7kpXBn8TE7Cm9P5WVoDk/AZemmP/NQEGze4raHXGS+o5VX3jbN5jQ234HMa9yXPtX0jUA8L9tzmJLozH8cViUmh9KHyB1EkWrj0qOTq68hR6Z3Fav5SxoeO88mjSa5qm3Q4HFbRm0hc5xmftPC31iMcw6LYhY+pzpYmQctzGNaeB82P2qR6c3DAwVj6RPKnwXNZQCbgKILyxJpzmTzkP4srZ6FxZZ8Nj+Vqkk3md/sAQpfFMv3ol7P4X+K0ji0E5mxc83dM+huVmjskymYXQ5oLgZoLERebxUCpdaojZUkA3A4HEhMTKxS9kaNGsHhcGirRjk5OdpqUTlpaWkV5nc6ndoKUHFxMZYuXYpJkyZZtiUuLg5dunTBjh07qtT2uiDq3W1333038vPzsW3bNhw+fBi5ubnYunUr8vPzcc8999RFGwVBEARBOA643W706NEDmZmZyvHMzEz07du3wmv69Omj5V+5ciV69uyp6ZH++c9/wufz4brrrrNsi8/nw3fffaeZ644nUU+S3n//fbz00kvo0KFD+FjHjh3x4osvast5giAIgiBUj1pxAVANxo4dizlz5mDevHn47rvvcO+992LPnj244447AADjx4/H8OHDw/nvuOMO7N69G2PHjsV3332HefPmYe7cuRg3bpxW9ty5c3HppZdWqDEaN24c1q5di507d+Kzzz7DZZddhvz8fNxwww3Vu5FaIGpzWygUqlCp7nK5ELLyVisIgiAIQtWoJXNbtFx55ZU4dOgQJk2ahKysLHTu3BkrVqxARkYGACArK0vxmdS6dWusWLEC9957L1588UWkp6fj+eefD2//L+eHH37AunXrsHLlygrr/eWXX3D11Vfj4MGDaNy4MXr37o2NGzeG660Pop4k/fGPf8To0aOxZMkSpKenAwD27duHe++9FwMGDKj1Bh5PbAEDtv9NvV3F6oSPt+QXN1bTzlJ1Uc6db+6VnO3zmv3bqrGkLyiL53gIx+AwIlbu+bVwA1aaI5ZlWGiOtDAodL3DZ1F+rJr2pZBOJIlCuhSrDWANktV/W648Ne2hdGwObcMvNf9nIRCrtqc0Re1Q1l7EZqs6o4IME8El9622pdziHxnW/JAuxW7hbZ9D4HB5rBuxrF87b37ayqWBpUaJ80cbxoXGqqHtM6ckhY3RdEa07T3y+bF2zUZ6JzvLn3hLv9X/tNw1dG/sTsJZwvor8+L5O+FPMB8r2neL+p61k3YLvZnh4Payuww1Hdme0G/ZH0AVGTlyJEaOHFnhuQULFmjH+vXrZ+kn8dRTTw0Luiti6dKlUbXxeBC1uW3GjBkoKChAq1at0KZNG7Rt2xatW7dGQUEBXnjhhbpooyAIgiCcfNRjWBLhKFGvJLVo0QJffPEFMjMz8f3338MwDHTs2BEDBw6si/YJgiAIwklJTXRFYWSiVCOq7Sdp0KBBGDRoUG22RRAEQRCEcmQ1qN6p1iRp7dq1ePrpp8POJDt06IC//vWvOOecc2q7fceXSM9dZI/25qoG7rIY8j0Up9qoSxuo2gz2daNpnizCMWi+icje7ouon8OM+Mk9BocDcBdwyBX1fFmMmg5SOsRGW74X9hFFfo9c1B7WSnC4A19DCscQR75//ByewMIfDN0va5DicujZFZH2g8MfaGFdyH9MHIWJoeZ5D6sdFIhRx1Jc1rEG233mGiHtv1BLf14Wmh3288MaHzpvsEaJQ9JYEeUfCCuNUZ3Xx0nWZLFGjP0gWYTGAI71J+uZOESK4VT7PmSwPo20fNQ21jCxnyHNrxDdC4dB0fyt0dDl75CzlPVwan4ON8T+zFg3xO8ha5D4u8f364hoT9ARtVJF+I0S9ZNetGgRBg4ciNjYWNxzzz246667EBMTgwEDBmDx4sV10UZBEARBOOmoDRcAv3+Jed0S9UrSE088galTp+Lee+8NHxs9ejSmTZuGxx57DNdcc02tNlAQBEEQTkrqyQWAcIyoJ0k///wzLrroIu34xRdfjAcffLBWGlVvRA5ILbyBmnb6eP8sm7jI/EbbvNllv7uQl35paZu33ZMVg01AkRQ1ozAktCxto5tzUVsMGiUBMrfpW3PVpIPCGTjUHe16WJEGaroklTK4ydxVZL7Fn8OQOCmsifcQpQ+r5XPfOkvUdf8QmRnYZMXL/FqYk2JzM4Y/Wb0/T27lIWg4zdtttS3r/G+mhTku5FH3bWuhMKI0Q1huyefmRPvBt/o32iJSh9a+IN9vdGFMuDzteVTuyaMCqK/ZFEo4SsgcR3XbXfyd4PBF7HKA7o3DD7nNzXuaOwh+9OaWZC1cEX9D2bzHYVCCXjKF0nupuSKJeNZB//Ext9WKcFuoEVE/6RYtWmD16tXa8dWrV6NFixa10ihBEARBEIT6JuqVpPvuuw/33HMPtmzZgr59+8Jms2HdunVYsGABnnvuubpooyAIgiCcfIi5rd6JepJ05513Ii0tDc888wz++c9/AgA6dOiAZcuW4ZJLLqn1BgqCIAjCSYtMcuqVarkAGDp0KIYOHVrbbflN4yqh7bikg/HHq5bNQIx63kfb9A2bmt/JoS7YnB+hg2Fbfdw+Nc3hAFhjxFoB3iLPGiMuj7UEWlgTGnV87/5k1tlQeXmqcMMWNA9H4D6ipr2H1fI9R8w1SJoOhXUlrOUgXQk/e4bDjpiFmAEAV0Hl8R5YE2QLWGh8CJuf3CmQpiZI7ggcRTw4zMvXNDzcPs7PLgNqe6uOVX+wRipagYL22lrcr1VYlkiorwPx6ovIWjlXIX0YLOBnY+eboWSQvlkGbdHXtYg0tniLfsBcb6d9Z+j2tO9GwLw+LU0aq8jwSEGLcDXC74eoJ0mff/45QqEQevXqpRz/7LPP4HA40LNnz1prnCAIgiCcrNSGcFuE3zUjauH2qFGjsHfvXu34vn37MGrUqFpplCAIgiCc9Ejstnon6pWkb7/9FmeccYZ2vHv37vj2229rpVGCIAiCcLJjM4yae5GXmVKNiHqS5PF4sH//fpxyyinK8aysLDid1Q4Fd2LgsB0LKcH2by3cgJpmHYrmV6nUfKByWJPiJmrae4R8/RRX7hOFbfGePPIrRLZ71hSVJpN+irQFTtIkefLUe2MfUP4kNX9ZgpoOxlIoC+o79nNkC3H4AzW/9zC1L5dCzBxRxQx28nnF/afpcth/DD37oMdOafV8XDbpfljq4a76s9ZCvgRZx0F9S6EqNA1SUE0bLvJBxWFHovStw5oke8jct48taB4GxcqvkYYW/sciLIi5OzQNrTx7dH+grP4gmt0f67c0f12kJ7PsK+5qC59c7D+MQ9BoYUxIw8RaQn4v+H7s2lin6+m8rq3kkDFqOuA1GWt+mXicLERtbhs0aBDGjx+PvLxjAa6OHDmCBx98UALeCoIgCEJtURvmNpnP1Yiol36eeeYZnHvuucjIyED37t0BAFu2bEFqaipee+21Wm+gIAiCIJyU1IZwu3ZactIS9SSpWbNm+Prrr/H666/jq6++QkxMDG666SZcffXVcLlc1gUIgiAIgmCNOJOsd6olIoqLi8Ntt91W222pdwz7MY2HjeffZH+30kZos3+63lXE9nw1exn51vGTZol1Mc6SY+XZKaYS+xHSNT9q2purGvdLG7DORM3PMZJ8Ker5kqYkNoihtI91MqwTUbM7i6i9rEE6ot6/u4B0N9w/Wswoi68Kay1IZ1PcWO0vTTN1UHUYU9RMFS1xLDd3fuX+bViHwRh2C02QhQYp5FEftt1H8b9I4xT0qOlALPltYp9TdnOLvz3AejQLzZBWAGVnP01WmiOr8hktHJn5//HWY63y/Pws+Y+hg/VjVnHyCM0fGI97F7+n9F6xnyOqz03vIWvxNB9ZBGsJNc0Sx4rjWHIW9++m9itjp0xmHicLv3GltSAIgiD8PpEAt/WPTJIEQRAE4UREzG31Tr1OkqZMmYK33noL33//PWJiYtC3b188+eSTaN++fTiPYRh49NFHMXv2bOTm5qJXr1548cUX0alTp3Aen8+HcePGYcmSJSgpKcGAAQMwc+ZMNG/ePKr22EIm5guLpV8rFwFWA5XrdRfwtnR1qbiMwppEhjmJNL0BgDvfYhs14fCp18ccUq/3x6vXlzSidCrVx+Y1rXOo/hL1Xt156nl3vpqO3a/WxyFctPAKFiYONumEaJt7gMyLxalsclLLS9in3n9Zoqrd8yWp5XsPk/2TTUwRsAsA2HiPO4dUofwcWiJGbVthC/VmvAdVc5v7iGo6dOWraUcpme/YZQCZbAwKiRPi907b9m0RwiZA7i/U07pJqYZb+Pk9tzLpWPrA0V6dY+2zujZIfc1hORjNJQB/07SxpibZ3QPYtEvfFXtAvbmQW/1zZOXegt1PWEkiNLM6m91ZRkBjU7lfUUOfNETtAqA2Wbt2LUaNGoWNGzciMzMTgUAAgwcPRlHRMdHJ1KlTMW3aNMyYMQOff/450tLSMGjQIBQUFITzjBkzBsuXL8fSpUuxbt06FBYW4sILL0SQ9BaCIAiC8Fuh3NxWkx+hZkQ9Sbrxxhvx8ccf10rl77//Pm688UZ06tQJXbt2xfz587Fnzx5s3rwZwNFVpOnTp2PChAkYNmwYOnfujIULF6K4uBiLFy8GAOTl5WHu3Ll45plnMHDgQHTv3h2LFi3CN998g1WrVtVKOwVBEAThuCM+kuqdqCdJBQUFGDx4MNq1a4fJkydj37591hdVkXIHlSkpR7dH7dy5E9nZ2Rg8eHA4j8fjQb9+/bB+/XoAwObNm1FWVqbkSU9PR+fOncN5GJ/Ph/z8fOVHEARBEE4kamMlSVaTakbUmqQ333wThw4dwqJFi7BgwQI88sgjGDhwIEaMGIFLLrmk2r6SDMPA2LFj8Yc//AGdO3cGAGRnZwMAUlNTlbypqanYvXt3OI/b7UaDBg20POXXM1OmTMGjjz5q3h62h2uhKtR0iKUgmviBy4tu5GoaJdrW749wGeBLIncBtK3bXUg6DZLAsJbAKswJ66UMh5r2NVLHRMhF7hAKSIOUq9bHGqS4/aouxs4hAizcMVj1PYcVKaX2lzQkPVisen38L6QJy1M7uIB0Pu4CNb+jpPIt/xoW27Stxp3hYT2VuY5F6zuujnQpdj/HmgClKYSLgzVC5pdr29IpREyIxr72HtP9aGFXtPZYaRMtNEhWW/4J0/qs7oX0VJqmh10IWOlsNP0Wneah4Tf3nxDwkl7N4rujpVljxfo7vj9Caz9rF9lVSuT5smh9Qwi/VaqlSWrYsCFGjx6NL7/8Eps2bULbtm1x/fXXIz09Hffeey927NgRdZl33XUXvv76ayxZskQ7Z+OX0zC0Y4xZnvKwKuU/e/fujbq9giAIglCnGEbNf4QaUSPhdlZWFlauXImVK1fC4XDgz3/+M7Zt24aOHTvi2WefrXI5d999N9555x189NFHyo60tLQ0ANBWhHJycsKrS2lpafD7/cjNza00D+PxeJCYmKj8CIIgCMKJRK2Y2mSeVCOiniSVlZXhzTffxIUXXoiMjAy88cYbuPfee5GVlYWFCxdi5cqVeO211zBp0iTLsgzDwF133YW33noLH374IVq3bq2cb926NdLS0pCZmRk+5vf7sXbtWvTt2xcA0KNHD7hcLiVPVlYWtm7dGs4jCIIgCL85RLhd70StSWratClCoRCuvvpqbNq0Cd26ddPynH/++UhOTrYsa9SoUVi8eDHefvttJCQkhFeMkpKSEBMTA5vNhjFjxmDy5Mlo165dWCweGxuLa665Jpx3xIgRuO+++9CwYUOkpKRg3Lhx6NKlCwYOHBjVvRm2yl34aMfZnq2ZqNlAz+EgzMu3sqczztLI+kiTRH57/DQ39pDeyUF+lizcGmkhVuKy1PMB8qvkKFbTsSQdYz9PHCaF/Tix/ksPy0LPgvJziJfiJuprUdqANEhx1F4KkxK7X9UgcfmM95CqQdKElqy1iChO98fF92quUQokuJV0WYJ672WxNG79qo7EWUxhSrg6zS8S6des/I9ZaqLIFE/Xs98lzqGH3lDvz866GtI8aViEObHSNEWDpn+y8s3GOku+npOa3yR6FmANkfl3w1LyxJoqCw8umu6TauBvqBY2xcrHlta/x8qz8jkl/H6IepL07LPP4vLLL4fX6600T4MGDfD/7Z15dFRVtv+/VZWqyhyGACEyQ4thUiA2BEwHW2RQX9OOyOOH8gRbFo9GiCNgPyKvlfWUVhpkcGD09fPxEG1tBSHYTN0JqJCgIkMagTAkQhAShiQ17d8fNkWdfSp1UiRkgP1Z666Ve++555y775BTd3/P3ocOHTLWtWjRIgDAoEGDlO3Lli3D2LFjAQDPPvssysvLMXHiRH8wyQ0bNiAuLk7pU0REBB566CF/MMnly5fDZjO90QRBEAShYRIywHF165DxXI0Ie5A0ZsyYWmucqiEqs1gsyMrKQlZWVpVlIiMjMX/+fMyfP7/W+iYIgiAI9Y4McuoVyd0WAFkvf8LVRt/8y7PhU7IpRICPuwG0T98Gdx2bth/oYuJT/L0sjUZlnNoZVwybhs2n6F80uTxYX9hncleymqrCWqpOqXfuV8s7zqkVaFP8GSb3Gv/s7mPT3C8mql8cuXvNp3qktGsbeZa5CVgqjAut1QrsF1galXL1fPV7K4TbwOBu4+4sngm9sol6LSqaqvttzPYRF3n4CJ7XRC3vaq5+ceb3Ir+22rRuDk81YbgXwaMpGKatc4whETT3Zuj6NBcQPz6MrwY8DYjmVja437TwCaYp/Zp3Ljy3vGm/9hwzWxjr11yroffza8Hbt1VyTUTAnx7J5nC9UK9pSQRBEARBCE59zm5buHAhOnbsiMjISPTt2xfbtm0LWX7Lli3o27cvIiMj0alTJyxevFjZv3z5clgsFm2pqKioUbtXGxkkCYIgCEJDpJ7iJK1atQpTpkzBjBkzkJeXh/T0dAwfPhyFhYVByx86dAh33XUX0tPTkZeXh+nTp2Py5MlYs2aNUi4+Ph5FRUXKEqhvDrfdukAGSYIgCILQAKmvtCSvvfYaxo0bh/HjxyMlJQVz585F27Zt/ZOtOIsXL0a7du0wd+5cpKSkYPz48XjssccwZ84c9XwsFiQlJSlLTdqtC0STFEBN8txwjZFpRoKW9oS7uJn2wmeYqBfYb+67t1WoJxXJNDPeSJ7ihLXN7hLHOXWd+/J9dvV4xwmmyWFpRpylqnAk4oJqDG+kaiwPW4+4yDQ9PC1KE556g2m0mjBtAtOxeNlETpv6dRjRxeoBrgSWhoXdG3zKvza1Oox7UNNpWEP/7uE6lPLmTJ8Wp6yi+XdqXx1nVX0Z77svKvQrxaT1C9c1YNKpGI/n5uIaLp7mxME1Rep+LbWFKYSBiRAhBLj2jWuUtCgkrC/EnlOjKU3XzhQygMuv+DszzJQtmr7MYGst3IRBZ8rTpij73I1r5rTX69VylDqdTjidTq2sy+XCzp078fzzzyvbhwwZUmU+1NzcXCV/KvBTKKAlS5bA7Xb705WdP38e7du3h9frxS233IL//M//RO/eva+43bpAviQJgiAIQkOEamEBsH37diQkJCjL7NmzgzZZUlICr9cbNGdqVflQi4uLg5b3eDwoKSkBANx0001Yvnw5Pv74Y7z33nuIjIzEwIED/WnMrqTdukC+JAmCIAhCA6Qm3g0/BPTv3x/r1q1TNgf7iqS0HWbO1GDlA7f3798f/fv39+8fOHAg+vTpg/nz52PevHlX3O7VRgZJgiAIgtAQqZUktQSbzVbtHKWJiYmw2Wwhc6ZykpKSgpaPiIhA8+bNgx5jtVpx6623+r8kXUm7dYEMkgIJ+DypaYa4f9+UhoShxRixhtYw+VRZi95eCH+63pa6buXh+VkcJLJwnQrTLMWr6xFMoxPB6otmaUocZep++3mm0dHSBbB4MOz8PNGqPoCfL0+twTVJxOQFmiYpSl2PPcFiB1WomqiyJPWxcpzjsYZYKg8bD6KlXmwtXkxgfBeTDoRfaxYbJvJHtfKYH9TyjjNMg8Sa8zlCazN4+z52rlwXY3Pzm5dVyHUnZiVN6PrCTP/D4yZx/R3XwXA9oK2CxZkyxDbS4igFEG7qIu2dE25aEgMmTVGocwnePlvnGiZenWZLU2Altm4oHvgc1t93jauPw+FA3759kZ2djXvvvde/PTs7GyNGjAh6TFpaGv7yl78o2zZs2IDU1FS/HolDRMjPz0fPnj2vuN26QAZJgiAIgtAAqRV32xWQmZmJMWPGIDU1FWlpaXjrrbdQWFiICRMmAACmTZuG48ePY+XKlQCACRMm4I033kBmZiYef/xx5ObmYsmSJXjvvff8db744ovo378/fvazn6GsrAzz5s1Dfn4+FixYUO126wMZJAmCIAhCQ6QGwSCVOsJk5MiROH36NGbNmoWioiL06NEDa9euRfv27QEARUVFSuyijh07Yu3atZg6dSoWLFiA5ORkzJs3D/fff7+/zNmzZ/Gb3/wGxcXFSEhIQO/evbF161b8/Oc/r3a79YGFqpNA7RqnrKwMCQkJSBs+CxH2qhP3BqJNp+Uh7/mnYlNGanYVvOwzvpYRm0+9NoTkD9WWMdw/+0xf0YxNsW+qlrezEAHcXeQsZS6e45VqAS1dAs97oq56olSXD782PISAK46HFAjtfnPHqust8lUXFHfv8WvNXSw83YEeDoLfW8zFw6d6B8CnhWvuLjtLs8HTivC0Juxc9DQnzNXJynPb8yn1PO2Jfu6G0BqmVBzhwp8N9hx6uLuNhQTg4TC0df7cc/ciw8auj/IshBk+weR25ylRTGk+wv3nq4XyiAqdAoffC1YX6yAX+PLHgp8ev1b8nRpGCAKPuwI5G2eitLS02lqfcPD/Txr2IiLsUeYDQvCPb/6M//fgQLzyyiu11LvrC/mSJAiCIAgNkNpwt13L+qm6QAZJgiAIgtAQ8ZE2kSVsrntfUc2QQZIgCIIgNERqQ5Mk1AgZJAVg8VWdTkTzdxvQQuAHaUvdoK7ydAba9F12QFifZE2+eqaTsDEtgJOlFfE6VOOUtwzdfEQF1wCxKf5epqvhtqlk06hZ/7itHGVutf1ydUpqeaL6GPA0JVGnWMiCMlVD5Y1S63PHqfXxaePa+XEdDNeChJoGzsr6WFoSTcfBj+d6KB+rzx6m5sgeWsNkDFEQZmoKzVZhTOMGzHo8rm+LIHbtLrD+cj2dZt/Q7fHz8YZKisBP3Rv6uTWGDND6yrR9TM9mSrHC3yOuePVeKm/GwlGcUcs7S7l2z5ASxmBbk57NmMZEuC6RQZIgCIIgNEBqK+K2cOXIIEkQBEEQGiKEWom4LVw5MkgSBEEQhAZIrcxukzFSjZBBUnUxxiAJT4Nk0jiZ0p7oWo+q6zbpn/h+va8sDclFtUD8UbVvUafV8uWJaod4DCgOj93DY/H4HFwHE9qYvD4ep4g/Bha2O/qkmkaksrkaS4vHe7mQFDpNSswP6n77ebXBiIusAyHuPa6j0OIM8ThHPF4X1yCxN4JeP9dTqfs94Oce+sHRdDJcZ2KIJ8ZlMTyukaY5MmkLeXd5f3haFN4B/iyZmuNxoMKJ+8RjVvFrzZ8LHneIt2VIZ8QxxVvjz2llAos5FaOWt5bwdxyrn2v7TLO+DPeShoU/G1WXN6ZYEa4ZZJAkCIIgCA0Rmd1W78ggSRAEQRAaIBZQzb9aySCrRsggKZCAwF2aW8IwTZunW+BT+PmnXD5tnk/X1dwKpumoIXbrLg02VbgyzHD/vH6231ap1h99Sq3fHcVsEa0aj6fW4PA0JB52fARLA0IVoW0XeZa5uyp46g71fMo6OJT18kS1Pn7teFqTi8ns2per6y2+VtcdZ1galIB7z8pch/y+465IzR2nuaMM7i++zu5bm5ZShlXH6zdMSw/lVg7WH/DQGfbQLilT6A1T6o9wp4lr9tNCfYRRGXcH2UK/k8DT2bBrZ3pnae4nw7XwxPA0JOxwfitUhv5vrt2rYb4STamhTOejXGsel0S4ZpFBkiAIgiA0RHzQdG5C3SKDJEEQBEFogFio5u42EZnXDBkkCYIgCEJDRITb9Y4MkgIgm8XvtzbFltC0CFzHw/UADG36rVY/22CcSxxQN/s8y6d16/507nznfQs9jdzoy+dTg5lO5FwbtYORp9WT5xojjvOsmnaE2Pnxqchaqonz6hT/iAusAXY+0adUHVBlE6aRYlObuf09rdW0JlTsVNYrmnDNEtNsBWikeHgD4roTY5qOMFMxGH6VmtOgMD2aMxwRTpDnwjBl3+riuh111RSOQpuiz0+P63R46gx2fcyhQEz2r3oX187xvvNwDFoKFIM+jIfG0PVc6sm5YtWT4++BqBJ2POu/j6ec0TpkuHY8bAq/lto7lqVn4uEeAq+lfJ25bpBBkiAIgiA0RIhqPiCT8VyNkEGSIAiCIDRAaiV3m1AjZJAkCIIgCA0R+ZJU78ggKRALLvvZeZwipmXg/nVNG2LQdnB/N9f5aFoJ9qBYmT4gsDzXmWhpPjStQuh4KHqqhNBxlHiaDq9d3e8sC61duJCkrscdV9t3lKkaIi32j0nLwGxpOl++P5LFfWpiUTVF59qx1BzN1eZ9Z1WDOErV/ZVN+PVQy8cUX9Zg8ftGS9nC9mtaOJaWRIslw+8du3pumu34Oo95xW8l9mBxjZKmf+PPlUETxJ9Tfm1tFYY0I6Z4OPwfGL8XeX+4ZKwG/8CMfdWuTXj1aylteGw4/oqKUK+lO4bfe2r5iPLQGiRT2hHTO1brP3/PGfV66rovID6b120QnQrXDDJIEgRBEIQGiMUX/uBWqF1kkCQIgiAIDZFacbeJv60mhDf/VhAEQRAE4TpBviQFQFbLZb81hfaXc/gnUaPWwJAzimsXtBxYoXK1GXQQXBtgOp5rA7g+yxMdOj9YdEloTZTXweIWVaj1mzRIPDYPX9f0Xk6mq+F6L3481zDx9tm684y67olU2+e52iLPKKt6HkB2vQL7p+kyQqfh01Mc8NgwhjhHmgbIgMXL4zjxmE+8w+oqz3EY9o9iQ246HjPLWF2Y56+FION6QJP+T+tAqAffEKAszHRjmtbPoA/j2kOei82qPsaIKA/9nBpjeJneiabcc7y4FsOKabACrp0v1Au4NpFgkvWODJIEQRAEoSFSK2lJaqkv1ykySBIEQRCEhkhtaJLkU1SNkEFSAF6HBZZ/TqXnIfg1FxSfSc2m7NsqWToCQ0gB/ulYm9HA3W9s3RYQ0l//7MzWTZ+d2QHcneZ1sHNlqR8iS9Tv6u5Y9WQrE9T6ok+q5W3M5cOnoWvTwPlLxDC31+piF5eHNDBMbQZzK3jYtHVnqZets/q01Bzssz67lyJL1LQrgS4qn525OsN1h4Xp7jFdC82VGqm+Ysim9pensuDtR1xkPhoGr9/L3eIGDxQ0N3pod5zm8uGuWC3EATue3Xo+9ixZWH94WhWl/zwFDb/2hpQtRvg7yVQ9646zlIdFCV2fj7/j+BR+wztSe+o19yNbNbxTZWghADJIEgRBEISGiQ+6jjBcZLRXI2SQJAiCIAgNEEstaJKEmiGDJEEQBEFokEicpPpGBkmBBEy35LoQrlHSU3Wwqvh0VkMaEh+7Epq/nbfHtBE8hIBSN0+pwo4N1DMBgCtO3e+KUZ31UadVY0RcVNe57bhton5kx5dzARhCw7UFfGqyQWOkwffzS0uhr53jHDt/pjOpaMpCDrDT5Romjr1M1SRpmiylbq4DYVPuuQaIpw3hei7+guXaPNaelRlbew4otAZJ6z/vD2s/4rxqG1uleq+6Y5kmKkzNknGitykVCA8vYdAsaWll7Pw9cXldSzHDp7yzd4JxSj2HP4esPZ+TX1u1uDGsiS30e0jDoCHSMLwHTLO+tBAIgRdPBh7XDTJIEgRBEISGSK3MbhNqggySBEEQBKEh4kPYQUA1ZIxVIyQtiSAIgiAIQhBkkBSAhS4vsKgL2dTFF2FRlkspTS4tPhtCLjYXKculbM/+rM+s/cC+Wegn/33gQhZcXqzqotXNcEdblcXrsChLdIlXWewX1IXsVmXxOdQl4oJXXS6qi8XjUxb/J+Z/LlYPW9w+ZYHFoi7seO06+0hZjPiILVAWq8unLPz8HOd8yuIs8yqL/ZxHXcrcymJ1e5WFbBb/ws+FX2urx6csmq3DhN9b3NaBfSObBRYvqYvbpyza8ew50u4ttlCERVl4e7YKX8iF94c/Z6bzNd5L7F7h/bO62cLuJb5f7Q+zFbO96R3C9xuvPbc1q4/31eJRF9O10J5zw8Lvdc0ege/EYOfP3xPavciuPX/P1AGXZrfVbLmythcuXIiOHTsiMjISffv2xbZt20KW37JlC/r27YvIyEh06tQJixcvVva//fbbSE9PR9OmTdG0aVMMHjwYX3zxhVImKysLFotFWZKSkq7sBGoJGSQJgiAIQkPEMJCr1nIF/rZVq1ZhypQpmDFjBvLy8pCeno7hw4ejsLAwaPlDhw7hrrvuQnp6OvLy8jB9+nRMnjwZa9as8ZfZvHkzRo0ahU2bNiE3Nxft2rXDkCFDcPz4caWu7t27o6ioyL988803Yfe/NhFNkiAIgiA0ROpJuP3aa69h3LhxGD9+PABg7ty5WL9+PRYtWoTZs2dr5RcvXox27dph7ty5AICUlBR89dVXmDNnDu6//34AwJ/+9CflmLfffhvvv/8+Pv/8czzyyCP+7REREfX+9SgQGSQFYPESLP+c5smn6vLUEVpIAD6Vl0/xZ1N5rWyqM5/+qk3bN6QaCfykqrXN6vJEqR8QeVqR6B/UVBB8qi1PM2KrYOdSwaY982nepszrltC2M6WC0KZCa+kIQn8qN5U3TdvWwj0YspV72DR1V5xan+Osut9+4fL10UJDsL5ZPeqNytOCmEJVmALZ+Rw8v05otHAKVj6vm98rzCXIwz1w+JR7t3r+lnJD6A6W6sPH1nkIAX7t+TR5/qleszcrz1Py8Otpq7x8vNep2t4Y3oDf92zdFCqD951P8a9xIlUeooBfax5iwJBCh6fIMaE991pokMYbAsDr9aKsrEzZ5nQ64XQ6tbIulws7d+7E888/r2wfMmQIcnJygtafm5uLIUOGKNuGDh2KJUuWwO12w263a8dcvHgRbrcbzZo1U7YXFBQgOTkZTqcT/fr1w8svv4xOnTpV6zyvBuJuEwRBEISGSG2424iwfft2JCQkKEuwL0IAUFJSAq/Xi1atWinbW7VqheLi4qDHFBcXBy3v8XhQUlIS9Jjnn38eN9xwAwYPHuzf1q9fP6xcuRLr16/H22+/jeLiYgwYMACnT58Ox2q1inxJEgRBEISGSC2FAOjfvz/WrVunbA72FSkQCw/GSaRtM5UPth0AXnnlFbz33nvYvHkzIiMj/duHDx/u/7tnz55IS0tD586dsWLFCmRmZobs79VCBkmCIAiC0ACprdxtNpsN8fHx1SqbmJgIm82mfTU6efKk9rXoEklJSUHLR0REoHnz5sr2OXPm4OWXX8bGjRvRq1evkH2JiYlBz549UVBQUK2+Xw1kkBRA4DReC3NI+5hUQPOHG+5jruvxstQVVkNIfs0/zxoMTN9QGc9TG6hHOkvVY+3nVA2SFs6fpw9gGiZNmxCmrsWk+dH1WKE1Spr2grdvSCVhLM+7w453x6lakZJe6rrjrHp8y7wKZT3iPGsgxPlp16Y8vGvJ0a4V1wix+9TiY/VrtmerNZw6raWK0LR/TB+m3Xqhry2vP8Klpj3xRLOHycFq52lEWOuaPs/0D1C71y//aatkejMP1xixvji53irM9D0MKz85LSWLutuYBiVcuEaJvXe4rU1pSbT+hdCB1lh/1YBxOBzo27cvsrOzce+99/q3Z2dnY8SIEUGPSUtLw1/+8hdl24YNG5CamqrokV599VX8/ve/x/r165GammrsS2VlJfbu3Yv09PQrPJuaI5okQRAEQWiI1JImKVwyMzPxzjvvYOnSpdi7dy+mTp2KwsJCTJgwAQAwbdo0ZUbahAkTcOTIEWRmZmLv3r1YunQplixZgqefftpf5pVXXsELL7yApUuXokOHDiguLkZxcTHOn7/8q/Dpp5/Gli1bcOjQIezYsQMPPPAAysrK8Oijj9bAiDVDviQJgiAIQkPEh3r5bDVy5EicPn0as2bNQlFREXr06IG1a9eiffv2AICioiIlZlLHjh2xdu1aTJ06FQsWLEBycjLmzZvnn/4P/BSc0uVy4YEHHlDamjlzJrKysgAAx44dw6hRo1BSUoIWLVqgf//+2L59u7/d+kAGSYIgCIIgKEycOBETJ04Mum/58uXatoyMDOzatavK+g4fPmxs83//93+r2706QwZJAfjD1QMg5vCOUGUjmn9bi8kRWkKkxTIy+dd5fTxWUWX85QIRLE5RzAlVp2KrVMUEFc1VnQWxu8JxVtU+aLoKrkVgMaC0H0IGzY8W+4eH0jHFP+H1c60B1yAZdDtc28H3e6LVDpZ2VA3oTlDbizrFdUSq7sXCYvv4ItXr42pyWQhzro26L+6oWpezRL1xrZpKhhHup3muWWLVmzRI/F7Ryhv0aFqaHf5Y8WuvPaeGe4+t28sq1eouqtfeHa+KlPh7weo2nK+JwOL8uePr/FB+bkyj5I1kMaHYc8djuZk0Phq1LEnS2jOkGLLwe4Hbg/835GKUgGsVLL3TVaE2gklew/qpukAGSYIgCILQEKmViNsySqoJMkgSBEEQhIaIfEmqd2SQVAX659TQLiD+LZlYtgZbZehP1ZqLh3069kSq+93R6nqgiy3uqIu1pZZ1NQl92bl7LaKCTTXW0n6EOfWXe7u4K9LgEtGnlavr4U7Z16eNh56m7YlUL+6F1qo9PVFqe033qP1JOKS6bLQ0LE42zVxzVwa0FaPuOt1DPTb2uNrXmBPqvWGr4Clo2I3NTe8MnUaEY2X3DkdLU+Jk96YpPAMPH2FIY6K5nAzXmnjaFeYe5C4bG39WoljqEO5mN7htdFf25XUtJUqYU+75c8fdabrt2SoLd8DX+blZuKvRIDkwutN4eR46xOhmZ6s8dInmdr+8X7uPhGsWGSQJgiAIQkOEyKi1qkYltdKV6xUZJAmCIAhCQ4R8Py01qqN2unK9IoMkQRAEQWiIiHC73rlmBkkLFy7Eq6++iqKiInTv3h1z586t01DmfMq+j+lMeBoSC5NqcH+6l2k/XHHqeuQZNs0+wEfuiWY6Ct5Xpj1wlLFUFvyHi6YVCO3751P0NY2P6YdRTVNXcG0C1xbYrKH3M7GCN0otf6EVe2yYfaJY0ms+Ld92geuADBosRqB9HWVq4xeT1GPLOrBp3g41qWVcIdO2XWB6Nm4rLYUM75whfAPTPFkvqu1ZInj+Hi6cCT2NO9zUF9q9yTRN2r3Nr42mC2KpMfi0ea6RCpFeCAjyLAUY3BQuQQuVoWmW1HVNX2UIV8Avtc/BbcXa0/Rs6irXBPH+8XemKTxE2CEHeHlmD2vAqhaiRbhmuSbSkqxatQpTpkzBjBkzkJeXh/T0dAwfPlyJCCoIgiAIjQof1XyR8VyNuCYGSa+99hrGjRuH8ePHIyUlBXPnzkXbtm2xaNGi+u6aIAiCIFwZ9ZS7TbhMox8kuVwu7Ny5E0OGDFG2DxkyBDk5OUGPqaysRFlZmbIIgiAIgiAE0ug1SSUlJfB6vWjVqpWyvVWrViguLg56zOzZs/Hiiy9q28lq8WsQrJWhU2vwEP5azBGXuoHHNdJ0MEz74I5S16N+VPsTdVKNtfNjyuXgPFwnwjUxVh5LhsczMU055a5/UywbfjjXkXCdSZhw3QxvX9NucMkW2+2KVx+L8kSm61FlPXCUqu1FnlHFE7ZypvniOhfefRtPdcHSnERX/7eNO1ZdL+uktl3RjGmUjqlxliJ/ZClTDNeOLFzvxTRITOfii+IxoQxxi7guxRCvLNw0IKbYPcRiavFYRdw+pmfJdO/z84cvMDVGaD0WP3evI7QWj6cr0uIG8Zcce8dZXax+ponittLimxlsb9IY6c8Rj6EVnr6N4wuIA+Wr7RwrVSFfguqdRv8l6RIWTVRI2rZLTJs2DaWlpf7l6NGjddFFQRAEQag+teJqk0FWTWj0X5ISExNhs9m0r0YnT57Uvi5dwul0wul0Bt0nCIIgCA0Cnw/GsOwmZIxUIxr9lySHw4G+ffsiOztb2Z6dnY0BAwbUU68EQRAEQWjsNPovSQCQmZmJMWPGIDU1FWlpaXjrrbdQWFiICRMmhFdRgP9XizHC/fPMf63lG2NwnZArLrQuJeYHVXxhZ7GMvE5VWBN1+nID9vNME8PzSZliyXAfuEnHYdBCaLnJ7DwACqvPkBtO04mYckCxa+Wxq7arbKY+BhdbsP6yp8TGUq9ZmU7Gfo7bX712PpYPjPfPHavuP5+sdiBQE8U1R5XNWLytWLUv1guhBVllTEPkszuU9Zjj7OQ5/FKwe4PftxZf6N9pVpfaf5P+jZfX4HGYGDyOk0mDxHU+/N7jsYY0zRKPDaRpvKrOj6blD2Nd8VnD009ZKw220+Kl8f3s3LhmyaSRMr0XDHGfOKb8alwTpedq4xVW3berRq0kuJVPSTXhmhgkjRw5EqdPn8asWbNQVFSEHj16YO3atWjfvn19d00QBEEQrgwRbtc718QgCQAmTpyIiRMn1nc3BEEQBKF28NWC8FoGWTXimhkk1QZWN8H6zxtS++ytpdpQjzWlwuBpRfinYOdZ5iaxq8dXtlHdHs5S9dO4o/SyS0eb4s/QUjEYPksbHzLmwdGm5Gsd4PWzVXbuFjc3NivPv9Krs9bhiVFv84omzN2WENq9xl2l3N0WdUp1p0VcZB1gaNPomQuoIlHtgIu51ChgN3e3eaNZZ51syj3ri4u17WGhKvi6rVK9D6N+qFDWrezUuWuVP0cm16+PQocQ4NdGc5HUMrby0K5rnk7Iy3xgNnYFLPx8+KPGvXkB9tPcZ+wd5ONT4LUwJdyW4bnZOaY0Kfy9w9snQwoXTdKghVFh/eHnz99zrDrN8xvi/MNNfyM0XmSQJAiCIAgNECICUQ1nt8n0thohgyRBEARBaIjQP/Ov1aiO2unK9UqjDwEgCIIgCIJwNZAvSYEEaOS4/17zd/NDmY+6vLmqe7FfZBqkM6qOhU/75mlMHOfV4+0X2NToQG2DSUvAz02b6sp9+QYdCPfPG4WCoctr06L5+Ri0A55YtYArjtk2JrSWIaJcXecapOgSpgc7repydK1E6HQQFYmqzoeHIOD3YqB2wutktrKza8WvrZ2HrmAaGyfvu2q7c234g6AGZeX3tdXNppWzm03Tr/Fry+4trnHStIFc48P1eQY9mMXHy/PUFnyavPoK9fB0RfwrALu3rNqzZkjpE/BskIPZht93TNtndYV+znx2Hp7BkG6I993wxcOc7ohplipDh1nhIQO8kWr/NQ2TFmokZPPa/sD3BH9nXDVqI2K2fEmqETJIEgRBEISGiM+n/yoNF5ndViNkkCQIgiAIDZFayb0mg6SaIJokQRAEQRCEIMiXpAA80Vbgn37uiHL2iZNpI3jcIy/TBzjPqsc7WKoKrpPhx0f/oGo7HGddyjr3x4eMD2NKM2LSFvC0Ivyu4dXxr8OsfS0GlSGukhYvhWkteGwaT7S6zvVdnii1fguTmUSfUk8g6qRqe1u5GgyIx3/xatoOtX53nF1ZL+3I7gWWe9l5Vl0P7L/PyfViPPiLQScSwTrHdBxem3r8uc5qXyuY9i7+sGr7+CPMdhfV+5p4fLGI0PotTe/FH1MwrFzzY9AsaSlueP+Yvo1rCZnezaaevtZDW4Th+rDYQYFpTng8tMoEnr6GvZPKWFwibhvtuVdXubZOSxfEjtf0YlwPpunP+LVnx/P+Mf0ZT7gDFkeKx5XSNEtcG8mzK/mq3ne1IJ8PVMPGSNxtNUIGSYIgCILQEKkVd5tQE2SQJAiCIAgNER8FCcMeJjLGqhEySArAEjiRgH2Kdsfw3Bfq/pgi1QXD3WH8+IgK9RMqd8/x9Au8P9q0+xDuNmPqBu5SMEyN5X3h6CEBDO0Z3G3cvXY+WXVXmabjcveV/YK6HnmGudd4qg2eWZ5nZucpa7i9eYqaBNUxwO3tKFPXef9dTQPsx2fk82vnZi4MK3Mp8DcAdzmw/RSv3ucudl+fdajXxhehdj7uqFreUarWZy1X3XE+B3dFMqcKT4mjhRjgU/jV8laWJoSHm+DuOW+0en7cTc7Rp6Fz13Hoae4RFexZcV3e72Zu5fM3MFcei0yhpYxhtou4yFyRXu5+Mk3hN7gquSszTIzpk9g7M4KHEmHvXO5+4+5J3R0X8Keoea8bZJAkCIIgCA0R8kHPuBhuHfIpqSbIIEkQBEEQGiDkI1BN3W3ib6sR8tFQEARBEAQhCPIlKQCLj/x+9wstWVqRcnU0HnUy9DTw8qZMe1Gm6loiLrK0IqYUAEH6qhQP1AGZjvWG/nzLNUKk5THhFZrWDRolhitetf1Fdi20KfysvgimOXKcUwvEFbJp6RWqUMVoH4PmiusVPFFq/3l6iMgfWQgBpo1wNVfr80YF9I9rjOx83jJbNf0q5RlgIngaDhVuKU9L1bZnnaqGx8XCH8QXqrZxnlWvRcR59Tnj07y5rkTTIGnTzpnuxBFaH2ZhF9OVwDRXdn4A658hXIbPGVqnY2UaqsAOumL5lHa1qDYl3vBceqPU+qyVXCfJDte0jIYp9QZtojbl3qBB0nWZhvZZfTztidXD7KGlPQnMSxKya7VHPbrbFi5ciFdffRVFRUXo3r075s6di/T09CrLb9myBZmZmdizZw+Sk5Px7LPPYsKECUqZNWvW4He/+x0OHjyIzp0746WXXsK9995bo3avNvIlSRAEQRAaIj76yeVWk+UKxkirVq3ClClTMGPGDOTl5SE9PR3Dhw9HYWFh0PKHDh3CXXfdhfT0dOTl5WH69OmYPHky1qxZ4y+Tm5uLkSNHYsyYMdi9ezfGjBmDhx56CDt27LjidusCGSQJgiAIQkOE6KevSTVZruCz12uvvYZx48Zh/PjxSElJwdy5c9G2bVssWrQoaPnFixejXbt2mDt3LlJSUjB+/Hg89thjmDNnjr/M3Llzceedd2LatGm46aabMG3aNNxxxx2YO3fuFbdbF4i7DZcjknrcl+fMel0sajKLfOvxMBcNG657WPZzLRu6Jzx3mzatnE91DuFuM33m5hD3FxkjdoesLkgD6qrPwiJmu9m0b3YtvDwaA+8ej3Ls4teORS/n19LkbtPsw1dZhG8PyxSvnR/7rM/dIJVq/b7ygHvHxo0Z2t0WdswVa2hb+PjF4BG/K9T73FvJbMOjJrNrAQ8LrcF+1/msoX/naS4bQ1RoU/gL3l9+7bj5tUzy7DXAp+Fz+HvHGrCuPRfsPrGy54D3ndz8HcPdT8zd5uG2C+1u06Kbm95D2vGh34n8vWFyt2nwsCrsYnnZveYNkCFc+l9xtaJZ22w22O12fOH+Kywh0ymYqUQ57HY7ysrU2CJOpxNOp1Mr73K5sHPnTjz//PPK9iFDhiAnJydoG7m5uRgyZIiybejQoViyZAncbjfsdjtyc3MxdepUrcylQdKVtFsXyCAJwLlz5wAAX2W/XM89EQRBEBoL586dQ0JCQq3XGxMTg6+++gpFRUW1Ut/WrVu1fs6cORNZWVla2ZKSEni9XrRq1UrZ3qpVKxQXFwetv7i4OGh5j8eDkpIStG7dusoyl+q8knbrAhkkAUhOTsbRo0cRFxcHC/81UguUlZWhbdu2OHr0KOLj42u9/msZsd2VI7arGWK/K+datx0R4dy5c0hOTr5qbfTq1Qu9evWqlboGDRqE5557TtkW7CtSIPx/IRGF/P8YrDzfXp06w233aiODJABWqxVt2rS56u3Ex8dfky+MukBsd+WI7WqG2O/KuZZtdzW+IF0tqnKtBSMxMRE2m037enPy5EntK88lkpKSgpaPiIhA8+bNQ5a5VOeVtFsXiHBbEARBEAQAgMPhQN++fZGdna1sz87OxoABA4Iek5aWppXfsGEDUlNTYbfbQ5a5VOeVtFsXyJckQRAEQRD8ZGZmYsyYMUhNTUVaWhreeustFBYW+uMeTZs2DcePH8fKlSsBABMmTMAbb7yBzMxMPP7448jNzcWSJUvw3nvv+et88skn8Ytf/AL/9V//hREjRuCjjz7Cxo0b8be//a3a7dYLJFx1KioqaObMmVRRUVHfXWl0iO2uHLFdzRD7XTliu8bPggULqH379uRwOKhPnz60ZcsW/75HH32UMjIylPKbN2+m3r17k8PhoA4dOtCiRYu0OlevXk1du3Ylu91ON910E61ZsyasdusDC5FkvxMEQRAEQeCIJkkQBEEQBCEIMkgSBEEQBEEIggySBEEQBEEQgiCDJEEQBEEQhCBc94OkrKwsWCwWZUlKSvLvP3/+PCZNmoQ2bdogKioKKSkpQZPt5ebm4pe//CViYmLQpEkTDBo0COXl5QCAw4cPY9y4cejYsSOioqLQuXNnzJw5Ey6XmlypsLAQ//Iv/4KYmBgkJiZi8uTJWplvvvkGGRkZiIqKwg033IBZs2ZdtfxB1aEu7BdIZWUlbrnlFlgsFuTn5yv7Gpv96tJ2n376Kfr164eoqCgkJibivvvuU/aL7YLb7sCBAxgxYgQSExMRHx+PgQMHYtOmTUodjc12QM3td/jwYe34S8vq1av95c6cOYMxY8YgISEBCQkJGDNmDM6ePav0pTHaT7iOqMeZdQ2CmTNnUvfu3amoqMi/nDx50r9//Pjx1LlzZ9q0aRMdOnSI3nzzTbLZbPTnP//ZXyYnJ4fi4+Np9uzZ9O2339KBAwdo9erV/umv69ato7Fjx9L69evp4MGD9NFHH1HLli3pqaee8tfh8XioR48edPvtt9OuXbsoOzubkpOTadKkSf4ypaWl1KpVK3r44Yfpm2++oTVr1lBcXBzNmTOnDiwVnLqwXyCTJ0+m4cOHEwDKy8vzb2+M9qsr273//vvUtGlTWrRoEe3fv5/27dtHq1ev9u8X21Vtuy5dutBdd91Fu3fvpgMHDtDEiRMpOjqaioqKiKhx2o6o5vbzeDzKsUVFRfTiiy9STEwMnTt3zl/PsGHDqEePHpSTk0M5OTnUo0cPuueee/z7G6v9hOsHGSTNnEk333xzlfu7d+9Os2bNUrb16dOHXnjhBf96v379lPXq8Morr1DHjh3962vXriWr1UrHjx/3b3vvvffI6XRSaWkpEREtXLiQEhISlJf47NmzKTk5mXw+X1jt1xZ1ab+1a9fSTTfdRHv27NEGSY3RfnVhO7fbTTfccAO98847VZYR2wXn1KlTBIC2bt3q31ZWVkYAaOPGjUTUOG1HVDv249xyyy302GOP+de/++47AkDbt2/3b8vNzSUAtG/fPiJqvPYTrh+ue3cbABQUFCA5ORkdO3bEww8/jO+//96/77bbbsPHH3+M48ePg4iwadMmHDhwAEOHDgXwU16ZHTt2oGXLlhgwYABatWqFjIwMJYpoMEpLS9GsWTP/em5uLnr06KEkTBw6dCgqKyuxc+dOf5mMjAwlB8/QoUNx4sQJHD58uDZMcUXUhf1++OEHPP7443j33XcRHR2t9aGx2u9q227Xrl04fvw4rFYrevfujdatW2P48OHYs2ePv4zYLrjtmjdvjpSUFKxcuRIXLlyAx+PBm2++iVatWqFv374AGq/tgJrZj7Nz507k5+dj3Lhx/m25ublISEhAv379/Nv69++PhIQE5OTk+Ms0VvsJ1wfX/SCpX79+WLlyJdavX4+3334bxcXFGDBgAE6fPg0AmDdvHrp164Y2bdrA4XBg2LBhWLhwIW677TYA8L9YsrKy8Pjjj+Ozzz5Dnz59cMcdd6CgoCBomwcPHsT8+fOVUOvFxcVaEr+mTZvC4XD4E/4FK3NpnScFrCvqwn5EhLFjx2LChAlITU0N2o/GaL+6sF1gmRdeeAGffPIJmjZtioyMDPz4448AxHZV2c5isSA7Oxt5eXmIi4tDZGQkXn/9dXz22Wdo0qSJ/9wbm+2AmtuPs2TJEqSkpCg5toqLi9GyZUutbMuWLUPapjHYT7h+uO5ztw0fPtz/d8+ePZGWlobOnTtjxYoVyMzMxLx587B9+3Z8/PHHaN++PbZu3YqJEyeidevWGDx4MHw+HwDgiSeewL/9278BAHr37o3PP/8cS5cuxezZs5X2Tpw4gWHDhuHBBx/E+PHjlX0Wi0XrHxEp23kZ+qd4MdixdUFd2G/+/PkoKyvDtGnTQvalsdmvLmx3qcyMGTNw//33AwCWLVuGNm3aYPXq1XjiiScAiO0A3XZEhIkTJ6Jly5bYtm0boqKi8M477+Cee+7Bl19+idatW1d5/g3ZdkDN7RdIeXk5/ud//ge/+93vtHauxDbVKVPf9hOuH677QRInJiYGPXv2REFBAcrLyzF9+nR8+OGHuPvuuwEAvXr1Qn5+PubMmYPBgwf7X5TdunVT6klJSUFhYaGy7cSJE7j99tv9ifsCSUpKwo4dO5RtZ86cgdvt9v9qSkpK0n45nTx5EgC0X1r1xdWw31//+lds375d+dwOAKmpqRg9ejRWrFhxTdjvatguWBmn04lOnTr5y4jtLsPvu08++QRnzpxBfHw8AGDhwoXIzs7GihUr8Pzzz18TtgPCt18g77//Pi5evIhHHnlE2Z6UlIQffvhBa+vUqVOKba4F+wnXLte9u41TWVmJvXv3onXr1nC73XC73bBaVTPZbDb/L9EOHTogOTkZ+/fvV8ocOHAA7du3968fP34cgwYNQp8+fbBs2TKtzrS0NHz77bcoKiryb9uwYQOcTqdf/5CWloatW7cq02M3bNiA5ORkdOjQoVbOv6ZcDfvNmzcPu3fvRn5+PvLz87F27VoAwKpVq/DSSy8BuDbsdzVs17dvXzidTqWM2+3G4cOH/WXEdpcJtN3FixcBQKvHarX667kWbAeEb79AlixZgl/96ldo0aKFsj0tLQ2lpaX44osv/Nt27NiB0tJSv1vuWrGfcA1T10rxhsZTTz1Fmzdvpu+//562b99O99xzD8XFxdHhw4eJiCgjI4O6d+9OmzZtou+//56WLVtGkZGRtHDhQn8dr7/+OsXHx9Pq1aupoKCAXnjhBYqMjKR//OMfRER0/Phx6tKlC/3yl7+kY8eOKdNmL3FpKuwdd9xBu3btoo0bN1KbNm2UqbBnz56lVq1a0ahRo+ibb76hDz74gOLj4+t1Kmxd2I9z6NChKkMANCb71ZXtnnzySbrhhhto/fr1tG/fPho3bhy1bNmSfvzxRyIS21Vlu1OnTlHz5s3pvvvuo/z8fNq/fz89/fTTZLfbKT8/n4gap+2Iasd+REQFBQVksVho3bp1QdsZNmwY9erVi3Jzcyk3N5d69uwZNARAY7OfcP1w3Q+SRo4cSa1btya73U7Jycl033330Z49e/z7i4qKaOzYsZScnEyRkZHUtWtX+sMf/qBNPZ09eza1adOGoqOjKS0tjbZt2+bft2zZMgIQdAnkyJEjdPfdd1NUVBQ1a9aMJk2apMUK+vrrryk9PZ2cTiclJSVRVlZWvU6DrQv7cYINkogan/3qynYul4ueeuopatmyJcXFxdHgwYPp22+/VcqI7YLb7ssvv6QhQ4ZQs2bNKC4ujvr3709r165VyjQ22xHVnv2mTZtGbdq0Ia/XG7Sd06dP0+jRoykuLo7i4uJo9OjRdObMGaVMY7SfcP1gIZKwpYIgCIIgCBzRJAmCIAiCIARBBkmCIAiCIAhBkEGSIAiCIAhCEGSQJAiCIAiCEAQZJAmCIAiCIARBBkmCIAiCIAhBkEGSIAiCIAhCEGSQJAj1iMViwZ///GcAwOHDh2GxWJCfn1+vfaoJxcXFuPPOOxETE4MmTZrUeftjx47Fr3/966vaxrVwnQRBqB6S4FYQGght27ZFUVEREhMTa7XeDh06YMqUKZgyZUqt1huM119/HUVFRcjPz0dCQsJVb4/zxz/+EbUZH3fs2LE4e/asfyALXL3rJAhCw0MGSYJwlXG73bDb7cZyNpsNSUlJddCjq8fBgwfRt29f/OxnP6vVel0uFxwOh7FcXQzMroXrJAhC9RB3m9BoOXXqFJKSkvDyyy/7t+3YsQMOhwMbNmyo8rhjx47h4YcfRrNmzRATE4PU1FTs2LHDv3/RokXo3LkzHA4HunbtinfffVc5vrCwECNGjEBsbCzi4+Px0EMP4YcffvDvz8rKwi233IKlS5eiU6dOcDqdICIUFBTgF7/4BSIjI9GtWzdkZ2cr9XI3zubNm2GxWPD5558jNTUV0dHRGDBggJK5/uDBgxgxYgRatWqF2NhY3Hrrrdi4caN//6BBg3DkyBFMnToVFosFFovFvy8nJwe/+MUvEBUVhbZt22Ly5Mm4cOFCSJuHsk2HDh2wZs0arFy5EhaLBWPHjg1axyWX2IsvvoiWLVsiPj4eTzzxhJLlfdCgQZg0aRIyMzORmJiIO++8EwCwZcsW/PznP4fT6UTr1q3x/PPPw+PxaHVfgojwyiuvoFOnToiKisLNN9+M999/X+nPnj17cPfddyM+Ph5xcXFIT0/HwYMHkZWVhRUrVuCjjz7y227z5s1B3W2mfg0aNAiTJ0/Gs88+i2bNmiEpKQlZWVkhbS0IQgOgXjPHCUIN+fTTT8lut9OXX35J586doy5dutCTTz5ZZflz585Rp06dKD09nbZt20YFBQW0atUqysnJISKiDz74gOx2Oy1YsID2799Pf/jDH8hms9Ff//pXIiLy+XzUu3dvuu222+irr76i7du3U58+fSgjI8PfxsyZMykmJoaGDh1Ku3btot27d/uznQ8aNIjy8vJoy5Yt1Lt3bwJAH374IRHpiXs3bdpEAKhfv360efNm2rNnD6Wnp9OAAQP8beXn59PixYvp66+/pgMHDtCMGTMoMjKSjhw5QkQ/JRht06YNzZo1i4qKiqioqIiIfkoYGhsbS6+//jodOHCA/v73v1Pv3r1p7NixVdrOZJuTJ0/SsGHD6KGHHqKioiI6e/Zs0HoeffRRio2NpZEjR9K3335Ln3zyCbVo0YKmT5/uL5ORkUGxsbH0zDPP0L59+2jv3r107Ngxio6OpokTJ9LevXvpww8/pMTERJo5c6ZS94gRI/zr06dPp5tuuok+++wzOnjwIC1btoycTidt3ryZiIiOHTtGzZo1o/vuu4++/PJL2r9/Py1dupT27dtH586do4ceeoiGDRvmt11lZaV2narTr4yMDIqPj6esrCw6cOAArVixgiwWC23YsKFKewuCUP/IIElo9EycOJFuvPFGGj16NPXo0YPKy8urLPvmm29SXFwcnT59Ouj+AQMG0OOPP65se/DBB+muu+4iIqINGzaQzWajwsJC//49e/YQAPriiy+I6KdBkt1up5MnT/rLrF+/nmw2Gx09etS/bd26ddUaJG3cuNF/zKeffkoAQp5jt27daP78+f719u3b0+uvv66UGTNmDP3mN79Rtm3bto2sVmuVdZtsQ0Q0YsQIevTRR6vsG9FPA5lmzZrRhQsX/NsWLVpEsbGx/mzyGRkZdMsttyjHTZ8+nbp27apkf1+wYIFyXOAg6fz58xQZGekfAF9i3LhxNGrUKCL6KYt9x44dyeVyVdnXwEEXkX6dqtOvjIwMuu2225R6br31VnruueeqtJMgCPWPuNuERs+cOXPg8Xjwf//3f/jTn/6EyMjIKsvm5+ejd+/eaNasWdD9e/fuxcCBA5VtAwcOxN69e/3727Zti7Zt2/r3d+vWDU2aNPGXAYD27dujRYsWSr3t2rVDmzZt/NvS0tKqdX69evXy/926dWsAwMmTJwEAFy5cwLPPPuvvQ2xsLPbt24fCwsKQde7cuRPLly9HbGysfxk6dCh8Ph8OHToU9BiTbcLh5ptvRnR0tH89LS0N58+fx9GjR/3bUlNTtfbT0tIUl+HAgQNx/vx5HDt2TGvju+++Q0VFBe68807lPFeuXImDBw8C+Ol+SE9Pr5ZmrCqq26/A6wj8dC0vXUdBEBomItwWGj3ff/89Tpw4AZ/PhyNHjmj/jAKJiooy1hf4zw74SddyaVvg31WVAYCYmBhtv6mdqgj8B37pGJ/PBwB45plnsH79esyZMwddunRBVFQUHnjgAUXfEwyfz4cnnngCkydP1va1a9euyuNC2aY2MNkwWPvB+gVcttGnn36KG264QdnndDoBVO9+MFHdfvGBmMVi8fdREISGiXxJEho1LpcLo0ePxsiRI/H73/8e48aNU0TUnF69eiE/Px8//vhj0P0pKSn429/+pmzLyclBSkoKgJ++GhUWFipfPL777juUlpb6ywTj0nEnTpzwb8vNza3WOYZi27ZtGDt2LO6991707NkTSUlJOHz4sFLG4XDA6/Uq2/r06YM9e/agS5cu2lLVLDKTbcJh9+7dKC8v969v374dsbGxypc2Trdu3ZCTk6MMOHNychAXF6cNgi6VdzqdKCws1M7x0pfAXr16Ydu2bXC73UHbDGa7mvZLEITGgwyShEbNjBkzUFpainnz5uHZZ59FSkoKxo0bV2X5UaNGISkpCb/+9a/x97//Hd9//z3WrFnjH7A888wzWL58ORYvXoyCggK89tpr+OCDD/D0008DAAYPHoxevXph9OjR2LVrF7744gs88sgjyMjI0NxDgQwePBhdu3bFI488gt27d2Pbtm2YMWNGjc+/S5cu+OCDD5Cfn4/du3fjX//1X7WvEx06dMDWrVtx/PhxlJSUAACee+455Obm4t///d+Rn5+PgoICfPzxx/jtb39bZVsm24SDy+XCuHHj8N1332HdunWYOXMmJk2aBKu16lfSxIkTcfToUfz2t7/Fvn378NFHH2HmzJnIzMwMelxcXByefvppTJ06FStWrMDBgweRl5eHBQsWYMWKFQCASZMmoaysDA8//DC++uorFBQU4N133/XPIOzQoQO+/vpr7N+/HyUlJUEHU+H2SxCERkQ9aaEEocZs2rSJIiIiaNu2bf5tR44coYSEBFq4cGGVxx0+fJjuv/9+io+Pp+joaEpNTaUdO3b49y9cuJA6depEdrudbrzxRlq5cqVy/JEjR+hXv/oVxcTEUFxcHD344INUXFzs3z9z5ky6+eabtXb3799Pt912GzkcDrrxxhvps88+q5Zw+8yZM/468vLyCAAdOnTIf8ztt99OUVFR1LZtW3rjjTcoIyNDmeGXm5tLvXr1IqfTSYGP/BdffEF33nknxcbGUkxMDPXq1YteeumlKu1WHdtUV7g9YsQI+o//+A9q3rw5xcbG0vjx46miosJfhp/DJTZv3ky33norORwOSkpKoueee47cbrdW9yV8Ph/98Y9/pK5du5LdbqcWLVrQ0KFDacuWLf4yu3fvpiFDhlB0dDTFxcVReno6HTx4kIh+mrF3yUYAaNOmTdp1qk6/gp1PdWwlCEL9YiGqxfC0giAIBoJFsa4tRo0aBZvNhv/+7/+u9boFQbj+kG/BgiA0ejweD7777jvk5uaie/fu9d0dQRCuEWSQJAhCo+fbb79FamoqunfvjgkTJtR3dwRBuEYQd5sgCIIgCEIQ5EuSIAiCIAhCEGSQJAiCIAiCEAQZJAmCIAiCIARBBkmCIAiCIAhBkEGSIAiCIAhCEGSQJAiCIAiCEAQZJAmCIAiCIARBBkmCIAiCIAhBkEGSIAiCIAhCEP4/GimDIbtwU9sAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "ds.B04.isel(time=0).plot( vmin=0, vmax=0.2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "## Data store to access single observations\n",
+    "Now, we initiate the data store to access each STAC item representing one observation tile. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 6.64 ms, sys: 992 μs, total: 7.63 ms\n",
+      "Wall time: 1.42 s\n"
      ]
     }
    ],
@@ -4030,15 +5560,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 55 μs, sys: 6 μs, total: 61 μs\n",
-      "Wall time: 67.7 μs\n"
+      "CPU times: user 23 μs, sys: 1 μs, total: 24 μs\n",
+      "Wall time: 25.3 μs\n"
      ]
     },
     {
@@ -4106,10 +5636,10 @@
        "type": "object"
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x772a474e35b0>"
+       "<xcube.util.jsonschema.JsonObjectSchema at 0x73654cb992b0>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4129,15 +5659,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 444 ms, sys: 8.13 ms, total: 452 ms\n",
-      "Wall time: 2.83 s\n"
+      "CPU times: user 180 ms, sys: 3 ms, total: 183 ms\n",
+      "Wall time: 3.41 s\n"
      ]
     },
     {
@@ -4177,7 +5707,7 @@
        "  'time_range': ('2020-07-03T10:30:31.024Z', '2020-07-03T10:30:31.024Z')}]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4203,15 +5733,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 44 μs, sys: 5 μs, total: 49 μs\n",
-      "Wall time: 52 μs\n"
+      "CPU times: user 31 μs, sys: 1e+03 ns, total: 32 μs\n",
+      "Wall time: 34.1 μs\n"
      ]
     },
     {
@@ -4238,10 +5768,10 @@
        "type": "object"
       },
       "text/plain": [
-       "<xcube.util.jsonschema.JsonObjectSchema at 0x772a47260d70>"
+       "<xcube.util.jsonschema.JsonObjectSchema at 0x73654cb99010>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -4261,15 +5791,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 596 ms, sys: 61 ms, total: 657 ms\n",
-      "Wall time: 2.36 s\n"
+      "CPU times: user 234 ms, sys: 19.1 ms, total: 253 ms\n",
+      "Wall time: 1.75 s\n"
      ]
     },
     {
@@ -4736,14 +6266,14 @@
        "    SCL            (y, x) float32 482MB dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;\n",
        "    solar_angle    (angle, angle_y, angle_x) float32 4kB dask.array&lt;chunksize=(2, 23, 23), meta=np.ndarray&gt;\n",
        "    viewing_angle  (angle, band, angle_y, angle_x) float32 13kB dask.array&lt;chunksize=(2, 3, 23, 23), meta=np.ndarray&gt;\n",
-       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-5357a5a7-fe60-4477-abff-29d06559b9f5' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-5357a5a7-fe60-4477-abff-29d06559b9f5' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 10980</li><li><span class='xr-has-index'>x</span>: 10980</li><li><span class='xr-has-index'>angle_x</span>: 23</li><li><span class='xr-has-index'>angle_y</span>: 23</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-d094955c-c358-4ba2-85df-7c9a4336c591' class='xr-section-summary-in' type='checkbox'  checked><label for='section-d094955c-c358-4ba2-85df-7c9a4336c591' class='xr-section-summary' >Coordinates: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4e+05 ... 5.097e+05 5.098e+05</div><input id='attrs-3ed91e20-b7f7-493e-8ee7-87e4531f8db8' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3ed91e20-b7f7-493e-8ee7-87e4531f8db8' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-545f7e8e-4afa-4b49-9e33-ff14e837ea27' class='xr-var-data-in' type='checkbox'><label for='data-545f7e8e-4afa-4b49-9e33-ff14e837ea27' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([399965., 399975., 399985., ..., 509735., 509745., 509755.],\n",
-       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.3e+06 ... 5.19e+06</div><input id='attrs-0f812d2a-5d6c-4125-82bd-fa714c3def38' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0f812d2a-5d6c-4125-82bd-fa714c3def38' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6b606bff-6667-48f6-a6ed-f7956e37427a' class='xr-var-data-in' type='checkbox'><label for='data-6b606bff-6667-48f6-a6ed-f7956e37427a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5300035., 5300025., 5300015., ..., 5190265., 5190255., 5190245.],\n",
-       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-417d92df-ec20-4cb3-9a16-16351dfa64ac' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-417d92df-ec20-4cb3-9a16-16351dfa64ac' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4cdae147-ac4e-487f-86fe-d7b4ed33930f' class='xr-var-data-in' type='checkbox'><label for='data-4cdae147-ac4e-487f-86fe-d7b4ed33930f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_x</span></div><div class='xr-var-dims'>(angle_x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4.05e+05 ... 5.05e+05 5.1e+05</div><input id='attrs-5df499c7-7f99-4268-ab77-2d658dfd0813' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5df499c7-7f99-4268-ab77-2d658dfd0813' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b38f7c59-b8c9-474f-885b-8dfd4ee9231a' class='xr-var-data-in' type='checkbox'><label for='data-b38f7c59-b8c9-474f-885b-8dfd4ee9231a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([399965., 404965., 409965., 414965., 419965., 424965., 429965., 434965.,\n",
+       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-7e2ed25d-c524-4fdc-9623-ea9ccccffc28' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7e2ed25d-c524-4fdc-9623-ea9ccccffc28' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>y</span>: 10980</li><li><span class='xr-has-index'>x</span>: 10980</li><li><span class='xr-has-index'>angle_x</span>: 23</li><li><span class='xr-has-index'>angle_y</span>: 23</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-143c0ecb-b33c-4ec5-8f48-c3952b8ab463' class='xr-section-summary-in' type='checkbox'  checked><label for='section-143c0ecb-b33c-4ec5-8f48-c3952b8ab463' class='xr-section-summary' >Coordinates: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4e+05 ... 5.097e+05 5.098e+05</div><input id='attrs-4fd50234-6141-47e8-b04f-1fc0188612b1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4fd50234-6141-47e8-b04f-1fc0188612b1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-89427a40-1c6c-48ec-9f4e-b65d3725a2ff' class='xr-var-data-in' type='checkbox'><label for='data-89427a40-1c6c-48ec-9f4e-b65d3725a2ff' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([399965., 399975., 399985., ..., 509735., 509745., 509755.],\n",
+       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.3e+06 ... 5.19e+06</div><input id='attrs-f5bff97c-98bf-4299-9951-2d1a79771d1f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f5bff97c-98bf-4299-9951-2d1a79771d1f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8a32ad31-86a0-442b-a7f7-4d966848deda' class='xr-var-data-in' type='checkbox'><label for='data-8a32ad31-86a0-442b-a7f7-4d966848deda' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5300035., 5300025., 5300015., ..., 5190265., 5190255., 5190245.],\n",
+       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-35bdfd0b-ef8e-40c8-af35-016ba3f4fd1d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-35bdfd0b-ef8e-40c8-af35-016ba3f4fd1d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f95cb372-dac8-4677-b484-0af4c0bdeb9e' class='xr-var-data-in' type='checkbox'><label for='data-f95cb372-dac8-4677-b484-0af4c0bdeb9e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_x</span></div><div class='xr-var-dims'>(angle_x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4.05e+05 ... 5.05e+05 5.1e+05</div><input id='attrs-f7d2b66f-e29e-4bdf-87c3-54fa300b6888' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-f7d2b66f-e29e-4bdf-87c3-54fa300b6888' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b322701c-153d-4520-be3b-f5e158dc1a30' class='xr-var-data-in' type='checkbox'><label for='data-b322701c-153d-4520-be3b-f5e158dc1a30' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([399965., 404965., 409965., 414965., 419965., 424965., 429965., 434965.,\n",
        "       439965., 444965., 449965., 454965., 459965., 464965., 469965., 474965.,\n",
-       "       479965., 484965., 489965., 494965., 499965., 504965., 509965.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_y</span></div><div class='xr-var-dims'>(angle_y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.295e+06 ... 5.19e+06</div><input id='attrs-a2e377e4-d563-4cc6-adff-343860b4dca2' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a2e377e4-d563-4cc6-adff-343860b4dca2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-ec3980ab-4ce1-46e7-bb69-39dd44ee08c9' class='xr-var-data-in' type='checkbox'><label for='data-ec3980ab-4ce1-46e7-bb69-39dd44ee08c9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5300245., 5295245., 5290245., 5285245., 5280245., 5275245., 5270245.,\n",
+       "       479965., 484965., 489965., 494965., 499965., 504965., 509965.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_y</span></div><div class='xr-var-dims'>(angle_y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.295e+06 ... 5.19e+06</div><input id='attrs-e28ca127-31a8-4a63-8284-2971e1d1d052' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e28ca127-31a8-4a63-8284-2971e1d1d052' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7274805e-5687-4e94-8785-fba0e4a9c217' class='xr-var-data-in' type='checkbox'><label for='data-7274805e-5687-4e94-8785-fba0e4a9c217' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5300245., 5295245., 5290245., 5285245., 5280245., 5275245., 5270245.,\n",
        "       5265245., 5260245., 5255245., 5250245., 5245245., 5240245., 5235245.,\n",
        "       5230245., 5225245., 5220245., 5215245., 5210245., 5205245., 5200245.,\n",
-       "       5195245., 5190245.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-5d02339b-552b-4136-83ed-ead812986a58' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-5d02339b-552b-4136-83ed-ead812986a58' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f5eef8e9-e515-4205-b58c-018fb9f779e6' class='xr-var-data-in' type='checkbox'><label for='data-f5eef8e9-e515-4205-b58c-018fb9f779e6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-a7661031-59bc-4f5a-a301-88a22b159156' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a7661031-59bc-4f5a-a301-88a22b159156' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f7f471dc-f99a-4e96-bd2e-5685893995e3' class='xr-var-data-in' type='checkbox'><label for='data-f7f471dc-f99a-4e96-bd2e-5685893995e3' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-64bd377b-e11d-4480-9bce-b26c361c90c1' class='xr-section-summary-in' type='checkbox'  checked><label for='section-64bd377b-e11d-4480-9bce-b26c361c90c1' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-9ae9bde6-87e2-4145-9efb-1f69aeef0c0d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9ae9bde6-87e2-4145-9efb-1f69aeef0c0d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7681416c-5060-43fe-8a69-f5e9457ee4e7' class='xr-var-data-in' type='checkbox'><label for='data-7681416c-5060-43fe-8a69-f5e9457ee4e7' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       5195245., 5190245.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-7d054787-bda6-4842-9751-0ca5229288b2' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7d054787-bda6-4842-9751-0ca5229288b2' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-c73b4b0b-549f-48b5-a63b-cd19fdc71c39' class='xr-var-data-in' type='checkbox'><label for='data-c73b4b0b-549f-48b5-a63b-cd19fdc71c39' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-a4babd75-a6ed-48f6-a1fe-ee0e75383f88' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a4babd75-a6ed-48f6-a1fe-ee0e75383f88' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-51933e13-4e52-4309-97ca-70700c62dae6' class='xr-var-data-in' type='checkbox'><label for='data-51933e13-4e52-4309-97ca-70700c62dae6' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8ab20e43-fa3b-4f5c-8f90-1c99df5c6554' class='xr-section-summary-in' type='checkbox'  checked><label for='section-8ab20e43-fa3b-4f5c-8f90-1c99df5c6554' class='xr-section-summary' >Data variables: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-5f9782e1-4a8f-4fae-8a9d-075ce6243920' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5f9782e1-4a8f-4fae-8a9d-075ce6243920' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-945e1653-00c7-4439-bdb0-56ab2bebd46e' class='xr-var-data-in' type='checkbox'><label for='data-945e1653-00c7-4439-bdb0-56ab2bebd46e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -4818,7 +6348,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-b9170e71-8568-4f8c-a9dd-662ad9da6b0d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-b9170e71-8568-4f8c-a9dd-662ad9da6b0d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-554e40f7-6879-48a2-a340-f378887407e4' class='xr-var-data-in' type='checkbox'><label for='data-554e40f7-6879-48a2-a340-f378887407e4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-55710f88-2b87-4f17-a045-3071a1dd9c15' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-55710f88-2b87-4f17-a045-3071a1dd9c15' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-37bbe1bb-3333-4fb5-89a6-40c637fb401c' class='xr-var-data-in' type='checkbox'><label for='data-37bbe1bb-3333-4fb5-89a6-40c637fb401c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -4893,7 +6423,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-a7011071-775d-4360-9f31-bbf1415f6857' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a7011071-775d-4360-9f31-bbf1415f6857' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3913baee-985f-47a4-81cb-d776572acd15' class='xr-var-data-in' type='checkbox'><label for='data-3913baee-985f-47a4-81cb-d776572acd15' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-3b68c54c-ed73-46d9-857a-9a701d348a63' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3b68c54c-ed73-46d9-857a-9a701d348a63' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4ba121cb-6025-4ab9-836d-950034f5c0fc' class='xr-var-data-in' type='checkbox'><label for='data-4ba121cb-6025-4ab9-836d-950034f5c0fc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -4968,7 +6498,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-0cbf1f19-1e26-47b2-a57c-35f35afa0861' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-0cbf1f19-1e26-47b2-a57c-35f35afa0861' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7b2b5e13-baad-4b31-96c7-708f7cdf9798' class='xr-var-data-in' type='checkbox'><label for='data-7b2b5e13-baad-4b31-96c7-708f7cdf9798' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>SCL</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-51690b44-d3e8-4a06-aa7e-11c5da381184' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-51690b44-d3e8-4a06-aa7e-11c5da381184' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5387f8e4-659d-40a1-b9e9-524dfbdada98' class='xr-var-data-in' type='checkbox'><label for='data-5387f8e4-659d-40a1-b9e9-524dfbdada98' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5043,7 +6573,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-ff5e90ec-3ff5-4a8e-a8de-bbdb27b8a4af' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-ff5e90ec-3ff5-4a8e-a8de-bbdb27b8a4af' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3dc350ba-85c5-4afe-9d8a-499512520f7b' class='xr-var-data-in' type='checkbox'><label for='data-3dc350ba-85c5-4afe-9d8a-499512520f7b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-cd2fb461-14b2-4eca-aae2-9e6fb203ba2c' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-cd2fb461-14b2-4eca-aae2-9e6fb203ba2c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-07184662-d49d-444b-b7b0-e1e0700077cf' class='xr-var-data-in' type='checkbox'><label for='data-07184662-d49d-444b-b7b0-e1e0700077cf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5121,7 +6651,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-84ba8989-658e-40f8-b8a9-a3661cd6aabd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-84ba8989-658e-40f8-b8a9-a3661cd6aabd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-418a14da-5f33-4a3b-a5b3-d26e2d31209e' class='xr-var-data-in' type='checkbox'><label for='data-418a14da-5f33-4a3b-a5b3-d26e2d31209e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-e8ebdc7e-0da7-4b0b-beeb-0a55fc3f6c8d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-e8ebdc7e-0da7-4b0b-beeb-0a55fc3f6c8d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d62ee1dc-dcc2-48bd-8a79-93f66e2fce3b' class='xr-var-data-in' type='checkbox'><label for='data-d62ee1dc-dcc2-48bd-8a79-93f66e2fce3b' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5215,25 +6745,25 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-6cd3971c-0b83-45b8-a635-1fc26476da29' class='xr-section-summary-in' type='checkbox'  ><label for='section-6cd3971c-0b83-45b8-a635-1fc26476da29' class='xr-section-summary' >Indexes: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-d8149dc3-440c-4ef1-ac59-d9fe45d6158e' class='xr-index-data-in' type='checkbox'/><label for='index-d8149dc3-440c-4ef1-ac59-d9fe45d6158e' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 399975.0, 399985.0, 399995.0, 400005.0, 400015.0, 400025.0,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9dcdf00f-15c7-4c2c-b80e-8adf452a8491' class='xr-section-summary-in' type='checkbox'  ><label for='section-9dcdf00f-15c7-4c2c-b80e-8adf452a8491' class='xr-section-summary' >Indexes: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-4d87e0e0-9376-4af0-a396-eaf110602f1d' class='xr-index-data-in' type='checkbox'/><label for='index-4d87e0e0-9376-4af0-a396-eaf110602f1d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 399975.0, 399985.0, 399995.0, 400005.0, 400015.0, 400025.0,\n",
        "       400035.0, 400045.0, 400055.0,\n",
        "       ...\n",
        "       509665.0, 509675.0, 509685.0, 509695.0, 509705.0, 509715.0, 509725.0,\n",
        "       509735.0, 509745.0, 509755.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-83ae0315-1458-4558-9528-fd8aedf7e84e' class='xr-index-data-in' type='checkbox'/><label for='index-83ae0315-1458-4558-9528-fd8aedf7e84e' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300035.0, 5300025.0, 5300015.0, 5300005.0, 5299995.0, 5299985.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-57fe4cd3-bfe1-4033-8d0e-d279270a343b' class='xr-index-data-in' type='checkbox'/><label for='index-57fe4cd3-bfe1-4033-8d0e-d279270a343b' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300035.0, 5300025.0, 5300015.0, 5300005.0, 5299995.0, 5299985.0,\n",
        "       5299975.0, 5299965.0, 5299955.0, 5299945.0,\n",
        "       ...\n",
        "       5190335.0, 5190325.0, 5190315.0, 5190305.0, 5190295.0, 5190285.0,\n",
        "       5190275.0, 5190265.0, 5190255.0, 5190245.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-3a698e17-fee4-4639-8485-99538d72b1eb' class='xr-index-data-in' type='checkbox'/><label for='index-3a698e17-fee4-4639-8485-99538d72b1eb' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 404965.0, 409965.0, 414965.0, 419965.0, 424965.0, 429965.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-a1a05ec0-ef46-4212-8380-f64987d9a3d3' class='xr-index-data-in' type='checkbox'/><label for='index-a1a05ec0-ef46-4212-8380-f64987d9a3d3' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 404965.0, 409965.0, 414965.0, 419965.0, 424965.0, 429965.0,\n",
        "       434965.0, 439965.0, 444965.0, 449965.0, 454965.0, 459965.0, 464965.0,\n",
        "       469965.0, 474965.0, 479965.0, 484965.0, 489965.0, 494965.0, 499965.0,\n",
        "       504965.0, 509965.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-cc16ec86-277a-4b2b-a4b9-9465be51aeea' class='xr-index-data-in' type='checkbox'/><label for='index-cc16ec86-277a-4b2b-a4b9-9465be51aeea' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300245.0, 5295245.0, 5290245.0, 5285245.0, 5280245.0, 5275245.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-b947c42a-4ab1-45db-b7ca-8c9ed5e3cbcd' class='xr-index-data-in' type='checkbox'/><label for='index-b947c42a-4ab1-45db-b7ca-8c9ed5e3cbcd' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300245.0, 5295245.0, 5290245.0, 5285245.0, 5280245.0, 5275245.0,\n",
        "       5270245.0, 5265245.0, 5260245.0, 5255245.0, 5250245.0, 5245245.0,\n",
        "       5240245.0, 5235245.0, 5230245.0, 5225245.0, 5220245.0, 5215245.0,\n",
        "       5210245.0, 5205245.0, 5200245.0, 5195245.0, 5190245.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-9c5849fd-bb11-4d58-81aa-a248bcfdcf8d' class='xr-index-data-in' type='checkbox'/><label for='index-9c5849fd-bb11-4d58-81aa-a248bcfdcf8d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-54394d95-25d8-4caa-a327-43d88c4dadd8' class='xr-index-data-in' type='checkbox'/><label for='index-54394d95-25d8-4caa-a327-43d88c4dadd8' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-8444893b-84cc-4777-b170-c5745a7f31d1' class='xr-section-summary-in' type='checkbox'  ><label for='section-8444893b-84cc-4777-b170-c5745a7f31d1' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>stac_item_id :</span></dt><dd>S2B_MSIL2A_20200705T101559_N0500_R065_T32TMT_20230530T175912</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-c0819d63-7ef8-433e-b219-db24e036ad33' class='xr-index-data-in' type='checkbox'/><label for='index-c0819d63-7ef8-433e-b219-db24e036ad33' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-f6aeac1c-4d6c-4509-ad62-5be136c0818f' class='xr-index-data-in' type='checkbox'/><label for='index-f6aeac1c-4d6c-4509-ad62-5be136c0818f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9ba5afa6-9405-42de-8ef2-d9cc4ea55edb' class='xr-section-summary-in' type='checkbox'  ><label for='section-9ba5afa6-9405-42de-8ef2-d9cc4ea55edb' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>stac_item_id :</span></dt><dd>S2B_MSIL2A_20200705T101559_N0500_R065_T32TMT_20230530T175912</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 2GB\n",
@@ -5257,7 +6787,7 @@
        "Attributes: (3)"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5281,24 +6811,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 40.4 s, sys: 2.52 s, total: 42.9 s\n",
-      "Wall time: 54.6 s\n"
+      "CPU times: user 18.8 s, sys: 665 ms, total: 19.5 s\n",
+      "Wall time: 30.3 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x772a470b7b10>"
+       "<matplotlib.collections.QuadMesh at 0x73654c7b42d0>"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -5327,15 +6857,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 308 ms, sys: 9.07 ms, total: 317 ms\n",
-      "Wall time: 2.57 s\n"
+      "CPU times: user 128 ms, sys: 4.12 ms, total: 132 ms\n",
+      "Wall time: 2.99 s\n"
      ]
     },
     {
@@ -5375,7 +6905,7 @@
        "  'time_range': ('2020-07-03T10:30:31.024Z', '2020-07-03T10:30:31.024Z')}]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -5394,15 +6924,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 427 ms, sys: 39.6 ms, total: 467 ms\n",
-      "Wall time: 1.65 s\n"
+      "CPU times: user 165 ms, sys: 13.9 ms, total: 179 ms\n",
+      "Wall time: 1.39 s\n"
      ]
     },
     {
@@ -5868,14 +7398,14 @@
        "    B02            (y, x) float32 482MB dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;\n",
        "    solar_angle    (angle, angle_y, angle_x) float32 4kB dask.array&lt;chunksize=(2, 23, 23), meta=np.ndarray&gt;\n",
        "    viewing_angle  (angle, band, angle_y, angle_x) float32 13kB dask.array&lt;chunksize=(2, 3, 23, 23), meta=np.ndarray&gt;\n",
-       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-7271f1d8-53f2-4f77-9186-3cb328fcd06a' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-7271f1d8-53f2-4f77-9186-3cb328fcd06a' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>x</span>: 10980</li><li><span class='xr-has-index'>y</span>: 10980</li><li><span class='xr-has-index'>angle_x</span>: 23</li><li><span class='xr-has-index'>angle_y</span>: 23</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-438fac3d-675e-40f4-b48d-411ba4c92d78' class='xr-section-summary-in' type='checkbox'  checked><label for='section-438fac3d-675e-40f4-b48d-411ba4c92d78' class='xr-section-summary' >Coordinates: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4e+05 ... 5.097e+05 5.098e+05</div><input id='attrs-d214596d-1528-4b74-9cbd-1b711d020f67' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-d214596d-1528-4b74-9cbd-1b711d020f67' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13b0a5de-e0b5-42e4-841e-92de4f674107' class='xr-var-data-in' type='checkbox'><label for='data-13b0a5de-e0b5-42e4-841e-92de4f674107' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([399965., 399975., 399985., ..., 509735., 509745., 509755.],\n",
-       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.3e+06 ... 5.19e+06</div><input id='attrs-00a66078-eee3-4854-a124-9b00f360534e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-00a66078-eee3-4854-a124-9b00f360534e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-0521a866-389e-4196-b1ed-c2a66cc2e8da' class='xr-var-data-in' type='checkbox'><label for='data-0521a866-389e-4196-b1ed-c2a66cc2e8da' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5300035., 5300025., 5300015., ..., 5190265., 5190255., 5190245.],\n",
-       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-143f5cc1-8193-4a12-b8bd-6a4c706169d5' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-143f5cc1-8193-4a12-b8bd-6a4c706169d5' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-1179dda7-474d-4feb-af37-7e86f0a4a663' class='xr-var-data-in' type='checkbox'><label for='data-1179dda7-474d-4feb-af37-7e86f0a4a663' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_x</span></div><div class='xr-var-dims'>(angle_x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4.05e+05 ... 5.05e+05 5.1e+05</div><input id='attrs-8f8aaaba-17d0-4285-a128-a09a1730acb9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-8f8aaaba-17d0-4285-a128-a09a1730acb9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4c444093-e7f1-4c5e-9a98-e0d6194189ce' class='xr-var-data-in' type='checkbox'><label for='data-4c444093-e7f1-4c5e-9a98-e0d6194189ce' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([399965., 404965., 409965., 414965., 419965., 424965., 429965., 434965.,\n",
+       "Attributes: (3)</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-4cd489f5-46bd-4887-8653-7bd242eddcca' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-4cd489f5-46bd-4887-8653-7bd242eddcca' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>x</span>: 10980</li><li><span class='xr-has-index'>y</span>: 10980</li><li><span class='xr-has-index'>angle_x</span>: 23</li><li><span class='xr-has-index'>angle_y</span>: 23</li><li><span class='xr-has-index'>angle</span>: 2</li><li><span class='xr-has-index'>band</span>: 3</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-ebfee705-f625-459c-81f6-32341462857a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-ebfee705-f625-459c-81f6-32341462857a' class='xr-section-summary' >Coordinates: <span>(7)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>x</span></div><div class='xr-var-dims'>(x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4e+05 ... 5.097e+05 5.098e+05</div><input id='attrs-a0c8d713-d9b0-4c06-800b-622b774e388d' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a0c8d713-d9b0-4c06-800b-622b774e388d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-7578f3b9-a390-428d-b9bf-2e449d29c585' class='xr-var-data-in' type='checkbox'><label for='data-7578f3b9-a390-428d-b9bf-2e449d29c585' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([399965., 399975., 399985., ..., 509735., 509745., 509755.],\n",
+       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>y</span></div><div class='xr-var-dims'>(y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.3e+06 ... 5.19e+06</div><input id='attrs-64151a3a-0b99-4bc8-a36f-a59f476fb705' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-64151a3a-0b99-4bc8-a36f-a59f476fb705' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6ed9efe9-40a3-4ae0-b2dc-a66eadcceeed' class='xr-var-data-in' type='checkbox'><label for='data-6ed9efe9-40a3-4ae0-b2dc-a66eadcceeed' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([5300035., 5300025., 5300015., ..., 5190265., 5190255., 5190245.],\n",
+       "      shape=(10980,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span>spatial_ref</span></div><div class='xr-var-dims'>()</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0</div><input id='attrs-23ef56ac-e3dd-454c-8c11-52346b19edb1' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-23ef56ac-e3dd-454c-8c11-52346b19edb1' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-77b1bd7b-70fd-4328-8e5b-f2192f0f869f' class='xr-var-data-in' type='checkbox'><label for='data-77b1bd7b-70fd-4328-8e5b-f2192f0f869f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>crs_wkt :</span></dt><dd>PROJCRS[&quot;WGS 84 / UTM zone 32N&quot;,BASEGEOGCRS[&quot;WGS 84&quot;,DATUM[&quot;World Geodetic System 1984&quot;,ELLIPSOID[&quot;WGS 84&quot;,6378137,298.257223563,LENGTHUNIT[&quot;metre&quot;,1]]],PRIMEM[&quot;Greenwich&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433]],ID[&quot;EPSG&quot;,4326]],CONVERSION[&quot;UTM zone 32N&quot;,METHOD[&quot;Transverse Mercator&quot;,ID[&quot;EPSG&quot;,9807]],PARAMETER[&quot;Latitude of natural origin&quot;,0,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8801]],PARAMETER[&quot;Longitude of natural origin&quot;,9,ANGLEUNIT[&quot;degree&quot;,0.0174532925199433],ID[&quot;EPSG&quot;,8802]],PARAMETER[&quot;Scale factor at natural origin&quot;,0.9996,SCALEUNIT[&quot;unity&quot;,1],ID[&quot;EPSG&quot;,8805]],PARAMETER[&quot;False easting&quot;,500000,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8806]],PARAMETER[&quot;False northing&quot;,0,LENGTHUNIT[&quot;metre&quot;,1],ID[&quot;EPSG&quot;,8807]]],CS[Cartesian,2],AXIS[&quot;easting&quot;,east,ORDER[1],LENGTHUNIT[&quot;metre&quot;,1]],AXIS[&quot;northing&quot;,north,ORDER[2],LENGTHUNIT[&quot;metre&quot;,1]],ID[&quot;EPSG&quot;,32632]]</dd><dt><span>semi_major_axis :</span></dt><dd>6378137.0</dd><dt><span>semi_minor_axis :</span></dt><dd>6356752.314245179</dd><dt><span>inverse_flattening :</span></dt><dd>298.257223563</dd><dt><span>reference_ellipsoid_name :</span></dt><dd>WGS 84</dd><dt><span>longitude_of_prime_meridian :</span></dt><dd>0.0</dd><dt><span>prime_meridian_name :</span></dt><dd>Greenwich</dd><dt><span>geographic_crs_name :</span></dt><dd>WGS 84</dd><dt><span>horizontal_datum_name :</span></dt><dd>World Geodetic System 1984</dd><dt><span>projected_crs_name :</span></dt><dd>WGS 84 / UTM zone 32N</dd><dt><span>grid_mapping_name :</span></dt><dd>transverse_mercator</dd><dt><span>latitude_of_projection_origin :</span></dt><dd>0.0</dd><dt><span>longitude_of_central_meridian :</span></dt><dd>9.0</dd><dt><span>false_easting :</span></dt><dd>500000.0</dd><dt><span>false_northing :</span></dt><dd>0.0</dd><dt><span>scale_factor_at_central_meridian :</span></dt><dd>0.9996</dd></dl></div><div class='xr-var-data'><pre>array(0)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_x</span></div><div class='xr-var-dims'>(angle_x)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>4e+05 4.05e+05 ... 5.05e+05 5.1e+05</div><input id='attrs-9b96a864-5574-47d2-93b0-0c5655cdc3ff' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-9b96a864-5574-47d2-93b0-0c5655cdc3ff' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-8a9ff0a6-0ca4-4050-832b-a23b022f562e' class='xr-var-data-in' type='checkbox'><label for='data-8a9ff0a6-0ca4-4050-832b-a23b022f562e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>x coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_x_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([399965., 404965., 409965., 414965., 419965., 424965., 429965., 434965.,\n",
        "       439965., 444965., 449965., 454965., 459965., 464965., 469965., 474965.,\n",
-       "       479965., 484965., 489965., 494965., 499965., 504965., 509965.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_y</span></div><div class='xr-var-dims'>(angle_y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.295e+06 ... 5.19e+06</div><input id='attrs-5ed2f64b-6d39-418f-b559-481780048049' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5ed2f64b-6d39-418f-b559-481780048049' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e47c1c96-142c-422a-94ec-da0241b217f5' class='xr-var-data-in' type='checkbox'><label for='data-e47c1c96-142c-422a-94ec-da0241b217f5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5300245., 5295245., 5290245., 5285245., 5280245., 5275245., 5270245.,\n",
+       "       479965., 484965., 489965., 494965., 499965., 504965., 509965.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle_y</span></div><div class='xr-var-dims'>(angle_y)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>5.3e+06 5.295e+06 ... 5.19e+06</div><input id='attrs-e3f0ab76-7c5c-488f-999e-059f0a2cd665' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-e3f0ab76-7c5c-488f-999e-059f0a2cd665' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-75521251-8e76-4358-bbbc-3ae55ea220ae' class='xr-var-data-in' type='checkbox'><label for='data-75521251-8e76-4358-bbbc-3ae55ea220ae' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>y coordinate of projection</dd><dt><span>standard_name :</span></dt><dd>projection_y_coordinate</dd></dl></div><div class='xr-var-data'><pre>array([5300245., 5295245., 5290245., 5285245., 5280245., 5275245., 5270245.,\n",
        "       5265245., 5260245., 5255245., 5250245., 5245245., 5240245., 5235245.,\n",
        "       5230245., 5225245., 5220245., 5215245., 5210245., 5205245., 5200245.,\n",
-       "       5195245., 5190245.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-db6c5a7d-190b-4e93-b24e-8b129c30bbee' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-db6c5a7d-190b-4e93-b24e-8b129c30bbee' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-d7457c4a-65e4-4be7-a2ed-6d2f778b14f2' class='xr-var-data-in' type='checkbox'><label for='data-d7457c4a-65e4-4be7-a2ed-6d2f778b14f2' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-bf8d9344-faa3-426f-8d66-f44c9b3d0c14' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bf8d9344-faa3-426f-8d66-f44c9b3d0c14' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a4ca199-d9b0-4ea7-b1ed-000fd3b859ca' class='xr-var-data-in' type='checkbox'><label for='data-2a4ca199-d9b0-4ea7-b1ed-000fd3b859ca' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-1d66e828-aad7-467e-b5e9-57e83cddc0db' class='xr-section-summary-in' type='checkbox'  checked><label for='section-1d66e828-aad7-467e-b5e9-57e83cddc0db' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-055aeeae-9917-4ff5-94d4-4c69cfa3ed07' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-055aeeae-9917-4ff5-94d4-4c69cfa3ed07' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13ecd4f8-bd04-4b1a-9986-78050134ad47' class='xr-var-data-in' type='checkbox'><label for='data-13ecd4f8-bd04-4b1a-9986-78050134ad47' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       5195245., 5190245.])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>angle</span></div><div class='xr-var-dims'>(angle)</div><div class='xr-var-dtype'>object</div><div class='xr-var-preview xr-preview'>&#x27;zenith&#x27; &#x27;azimuth&#x27;</div><input id='attrs-606e1fdb-1de4-4fc2-ab00-f344eeafb566' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-606e1fdb-1de4-4fc2-ab00-f344eeafb566' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-dcd534c5-13f0-4446-ba24-f3d137e8f0cb' class='xr-var-data-in' type='checkbox'><label for='data-dcd534c5-13f0-4446-ba24-f3d137e8f0cb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=object)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>band</span></div><div class='xr-var-dims'>(band)</div><div class='xr-var-dtype'>&lt;U3</div><div class='xr-var-preview xr-preview'>&#x27;B02&#x27; &#x27;B03&#x27; &#x27;B04&#x27;</div><input id='attrs-1cabfb8a-7110-4b7e-bc64-dad8a89b649e' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-1cabfb8a-7110-4b7e-bc64-dad8a89b649e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6a0b4747-0f69-40a8-9a48-f7ea0938dabc' class='xr-var-data-in' type='checkbox'><label for='data-6a0b4747-0f69-40a8-9a48-f7ea0938dabc' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;&lt;U3&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-a3224e72-8da2-4d8c-8b4a-fc28c96025da' class='xr-section-summary-in' type='checkbox'  checked><label for='section-a3224e72-8da2-4d8c-8b4a-fc28c96025da' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>B04</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-cc0e38be-8c07-4efe-a89d-fa2338c285aa' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-cc0e38be-8c07-4efe-a89d-fa2338c285aa' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-4d99bdd7-d72c-41df-a0ee-97f9ef902185' class='xr-var-data-in' type='checkbox'><label for='data-4d99bdd7-d72c-41df-a0ee-97f9ef902185' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -5950,7 +7480,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-de32c8db-c59d-4728-ac7c-4db911e1c179' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-de32c8db-c59d-4728-ac7c-4db911e1c179' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e39c034c-00d4-473c-b059-6f2a2ee11eee' class='xr-var-data-in' type='checkbox'><label for='data-e39c034c-00d4-473c-b059-6f2a2ee11eee' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B03</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-15f46853-06ac-49c6-8036-fcb177722c76' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-15f46853-06ac-49c6-8036-fcb177722c76' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-fed78e5b-1d48-4549-9bdd-c175bd021dcd' class='xr-var-data-in' type='checkbox'><label for='data-fed78e5b-1d48-4549-9bdd-c175bd021dcd' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6025,7 +7555,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-53e2a852-da44-491a-83bc-539f48030446' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-53e2a852-da44-491a-83bc-539f48030446' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-cf7ec683-ea69-4d0d-a076-1f590e536b80' class='xr-var-data-in' type='checkbox'><label for='data-cf7ec683-ea69-4d0d-a076-1f590e536b80' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>B02</span></div><div class='xr-var-dims'>(y, x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1024, 1024), meta=np.ndarray&gt;</div><input id='attrs-1048d4fd-baad-4c05-b93c-1d64c4dc88f3' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-1048d4fd-baad-4c05-b93c-1d64c4dc88f3' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-47e4d707-1a04-4774-88db-ab33f14478f1' class='xr-var-data-in' type='checkbox'><label for='data-47e4d707-1a04-4774-88db-ab33f14478f1' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>grid_mapping :</span></dt><dd>spatial_ref</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6100,7 +7630,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-0aa96c31-f533-4680-82ae-ba8fb21e5268' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-0aa96c31-f533-4680-82ae-ba8fb21e5268' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-eb933fb8-1bfe-445d-b71e-eb907fcfacfa' class='xr-var-data-in' type='checkbox'><label for='data-eb933fb8-1bfe-445d-b71e-eb907fcfacfa' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>solar_angle</span></div><div class='xr-var-dims'>(angle, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-62298453-2342-4921-b916-03991fec152f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-62298453-2342-4921-b916-03991fec152f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-be91b5c2-23d4-40dd-b3c5-fceb80adf691' class='xr-var-data-in' type='checkbox'><label for='data-be91b5c2-23d4-40dd-b3c5-fceb80adf691' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6178,7 +7708,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-84fe1894-c5e1-4d6a-adf1-d633b70babdd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-84fe1894-c5e1-4d6a-adf1-d633b70babdd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-2a49b5ae-4b69-427e-8499-593205c54896' class='xr-var-data-in' type='checkbox'><label for='data-2a49b5ae-4b69-427e-8499-593205c54896' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>viewing_angle</span></div><div class='xr-var-dims'>(angle, band, angle_y, angle_x)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(2, 3, 23, 23), meta=np.ndarray&gt;</div><input id='attrs-a4ad023a-c15a-401a-a7c6-e203559bd88f' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-a4ad023a-c15a-401a-a7c6-e203559bd88f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-3816947b-ef98-4867-8b7c-53175b52bf02' class='xr-var-data-in' type='checkbox'><label for='data-3816947b-ef98-4867-8b7c-53175b52bf02' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -6272,25 +7802,25 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-b699776c-450b-4cb7-bc04-ba2143ddfdb4' class='xr-section-summary-in' type='checkbox'  ><label for='section-b699776c-450b-4cb7-bc04-ba2143ddfdb4' class='xr-section-summary' >Indexes: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-f99889ef-d468-4b49-9b53-118510ed9f72' class='xr-index-data-in' type='checkbox'/><label for='index-f99889ef-d468-4b49-9b53-118510ed9f72' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 399975.0, 399985.0, 399995.0, 400005.0, 400015.0, 400025.0,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-118bfd8f-ef1d-4fc8-8d82-0361e8717eea' class='xr-section-summary-in' type='checkbox'  ><label for='section-118bfd8f-ef1d-4fc8-8d82-0361e8717eea' class='xr-section-summary' >Indexes: <span>(6)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-31d4b7e8-270a-49ef-b007-c7e091f2241a' class='xr-index-data-in' type='checkbox'/><label for='index-31d4b7e8-270a-49ef-b007-c7e091f2241a' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 399975.0, 399985.0, 399995.0, 400005.0, 400015.0, 400025.0,\n",
        "       400035.0, 400045.0, 400055.0,\n",
        "       ...\n",
        "       509665.0, 509675.0, 509685.0, 509695.0, 509705.0, 509715.0, 509725.0,\n",
        "       509735.0, 509745.0, 509755.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-add46f53-dde9-44a2-9082-8289168d3022' class='xr-index-data-in' type='checkbox'/><label for='index-add46f53-dde9-44a2-9082-8289168d3022' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300035.0, 5300025.0, 5300015.0, 5300005.0, 5299995.0, 5299985.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;x&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-b1724df7-b3e9-4725-9f59-a14da7ffc091' class='xr-index-data-in' type='checkbox'/><label for='index-b1724df7-b3e9-4725-9f59-a14da7ffc091' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300035.0, 5300025.0, 5300015.0, 5300005.0, 5299995.0, 5299985.0,\n",
        "       5299975.0, 5299965.0, 5299955.0, 5299945.0,\n",
        "       ...\n",
        "       5190335.0, 5190325.0, 5190315.0, 5190305.0, 5190295.0, 5190285.0,\n",
        "       5190275.0, 5190265.0, 5190255.0, 5190245.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-fb0806ca-db13-42de-a4f2-0a0b620357be' class='xr-index-data-in' type='checkbox'/><label for='index-fb0806ca-db13-42de-a4f2-0a0b620357be' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 404965.0, 409965.0, 414965.0, 419965.0, 424965.0, 429965.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;y&#x27;, length=10980))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_x</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-a3c66b71-5246-463b-bc7d-97c53d3072a2' class='xr-index-data-in' type='checkbox'/><label for='index-a3c66b71-5246-463b-bc7d-97c53d3072a2' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([399965.0, 404965.0, 409965.0, 414965.0, 419965.0, 424965.0, 429965.0,\n",
        "       434965.0, 439965.0, 444965.0, 449965.0, 454965.0, 459965.0, 464965.0,\n",
        "       469965.0, 474965.0, 479965.0, 484965.0, 489965.0, 494965.0, 499965.0,\n",
        "       504965.0, 509965.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-7b59dfa4-72b4-4d26-8dc6-b348cf9dbb2e' class='xr-index-data-in' type='checkbox'/><label for='index-7b59dfa4-72b4-4d26-8dc6-b348cf9dbb2e' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300245.0, 5295245.0, 5290245.0, 5285245.0, 5280245.0, 5275245.0,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_x&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle_y</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-dd00416a-71e9-44e3-aa93-459f4e4a244e' class='xr-index-data-in' type='checkbox'/><label for='index-dd00416a-71e9-44e3-aa93-459f4e4a244e' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([5300245.0, 5295245.0, 5290245.0, 5285245.0, 5280245.0, 5275245.0,\n",
        "       5270245.0, 5265245.0, 5260245.0, 5255245.0, 5250245.0, 5245245.0,\n",
        "       5240245.0, 5235245.0, 5230245.0, 5225245.0, 5220245.0, 5215245.0,\n",
        "       5210245.0, 5205245.0, 5200245.0, 5195245.0, 5190245.0],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-d04ef4f4-8a48-402b-a1e2-d8b017fcb960' class='xr-index-data-in' type='checkbox'/><label for='index-d04ef4f4-8a48-402b-a1e2-d8b017fcb960' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-1000fa5c-4e12-4315-9935-e1f655b16c1f' class='xr-index-data-in' type='checkbox'/><label for='index-1000fa5c-4e12-4315-9935-e1f655b16c1f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-3b2ecfa8-6118-4507-b985-fd907a6fe8dd' class='xr-section-summary-in' type='checkbox'  ><label for='section-3b2ecfa8-6118-4507-b985-fd907a6fe8dd' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>stac_item_id :</span></dt><dd>S2B_MSIL1C_20200705T101559_N0500_R065_T32TMT_20230530T084300</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;angle_y&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>angle</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-05657f49-933e-4ffe-accf-ec36a2278dc7' class='xr-index-data-in' type='checkbox'/><label for='index-05657f49-933e-4ffe-accf-ec36a2278dc7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;zenith&#x27;, &#x27;azimuth&#x27;], dtype=&#x27;object&#x27;, name=&#x27;angle&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>band</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-4db5d87d-edd3-417c-9c65-bf19dcc4a4ec' class='xr-index-data-in' type='checkbox'/><label for='index-4db5d87d-edd3-417c-9c65-bf19dcc4a4ec' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([&#x27;B02&#x27;, &#x27;B03&#x27;, &#x27;B04&#x27;], dtype=&#x27;object&#x27;, name=&#x27;band&#x27;))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-31a162b2-d1c8-47b7-83ac-119db4c8dd0e' class='xr-section-summary-in' type='checkbox'  ><label for='section-31a162b2-d1c8-47b7-83ac-119db4c8dd0e' class='xr-section-summary' >Attributes: <span>(3)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>stac_catalog_url :</span></dt><dd>https://stac.dataspace.copernicus.eu/v1</dd><dt><span>stac_item_id :</span></dt><dd>S2B_MSIL1C_20200705T101559_N0500_R065_T32TMT_20230530T084300</dd><dt><span>xcube_stac_version :</span></dt><dd>1.0.1.dev0</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 1GB\n",
@@ -6313,7 +7843,7 @@
        "Attributes: (3)"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -6330,24 +7860,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 38.4 s, sys: 2.33 s, total: 40.7 s\n",
-      "Wall time: 49.9 s\n"
+      "CPU times: user 18 s, sys: 619 ms, total: 18.6 s\n",
+      "Wall time: 25.8 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<matplotlib.collections.QuadMesh at 0x772a46a89590>"
+       "<matplotlib.collections.QuadMesh at 0x73654c6a1d10>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     },

--- a/examples/notebooks/sentinel_2_planetary_computer.ipynb
+++ b/examples/notebooks/sentinel_2_planetary_computer.ipynb
@@ -1385,7 +1385,7 @@
     "    data_id=\"sentinel-2-l2a\",\n",
     "    bbox=[9.7, 53.3, 10.3, 53.8],\n",
     "    time_range=[\"2020-07-15\", \"2020-08-01\"],\n",
-    "    spatial_res=10 / 111320, # meter in degree\n",
+    "    spatial_res=10 / 111320,  # meter in degree\n",
     "    crs=\"EPSG:4326\",\n",
     "    asset_names=[\"B02\", \"B03\", \"B04\"],\n",
     "    add_angles=True,\n",

--- a/examples/notebooks/sentinel_3_cdse.ipynb
+++ b/examples/notebooks/sentinel_3_cdse.ipynb
@@ -1200,7 +1200,7 @@
     "    data_id=\"sentinel-3-syn-2-syn-ntc\",\n",
     "    bbox=[8, 52, 12, 55],\n",
     "    time_range=[\"2020-07-31\", \"2020-08-01\"],\n",
-    "    spatial_res=300 / 111320, # meter in degree\n",
+    "    spatial_res=300 / 111320,  # meter in degree\n",
     "    crs=\"EPSG:4326\",\n",
     "    asset_names=[\"syn_Oa01_reflectance\", \"syn_Oa02_reflectance\"],\n",
     ")\n",
@@ -1250,7 +1250,7 @@
    ],
    "source": [
     "%%time\n",
-    "ds.SDR_Oa01.isel(time=-2).plot(vmin=0., vmax=0.1)"
+    "ds.SDR_Oa01.isel(time=-2).plot(vmin=0.0, vmax=0.1)"
    ]
   },
   {
@@ -3710,11 +3710,7 @@
    ],
    "source": [
     "%%time\n",
-    "ds = store.open_data(\n",
-    "    data_id,\n",
-    "    apply_rectification=False,\n",
-    "    add_error_bands=False\n",
-    ")\n",
+    "ds = store.open_data(data_id, apply_rectification=False, add_error_bands=False)\n",
     "ds"
    ]
   },

--- a/test/accessor/test__init__.py
+++ b/test/accessor/test__init__.py
@@ -21,21 +21,27 @@
 
 import unittest
 
-from xcube_stac.accessors import (BaseStacItemAccessor,
-                                  Sen2CdseStacArdcAccessor,
-                                  Sen2CdseStacItemAccessor,
-                                  Sen2PlanetaryComputerStacArdcAccessor,
-                                  Sen2PlanetaryComputerStacItemAccessor,
-                                  Sen3CdseStacArdcAccessor,
-                                  Sen3CdseStacItemAccessor,
-                                  guess_ardc_accessor, guess_item_accessor,
-                                  list_ardc_data_ids)
-from xcube_stac.constants import (DATA_STORE_ID_CDSE, DATA_STORE_ID_CDSE_ARDC,
-                                  DATA_STORE_ID_PC, DATA_STORE_ID_PC_ARDC)
+from xcube_stac.accessors import (
+    BaseStacItemAccessor,
+    Sen2CdseStacArdcAccessor,
+    Sen2CdseStacItemAccessor,
+    Sen2PlanetaryComputerStacArdcAccessor,
+    Sen2PlanetaryComputerStacItemAccessor,
+    Sen3CdseStacArdcAccessor,
+    Sen3CdseStacItemAccessor,
+    guess_ardc_accessor,
+    guess_item_accessor,
+    list_ardc_data_ids,
+)
+from xcube_stac.constants import (
+    DATA_STORE_ID_CDSE,
+    DATA_STORE_ID_CDSE_ARDC,
+    DATA_STORE_ID_PC,
+    DATA_STORE_ID_PC_ARDC,
+)
 
 
 class AccessorInitTest(unittest.TestCase):
-
     # ------------------------------------------------------------------
     # guess_item_accessor
     # ------------------------------------------------------------------

--- a/test/accessor/test__init__.py
+++ b/test/accessor/test__init__.py
@@ -21,24 +21,17 @@
 
 import unittest
 
-from xcube_stac.accessors import (
-    guess_item_accessor,
-    guess_ardc_accessor,
-    list_ardc_data_ids,
-    BaseStacItemAccessor,
-    Sen2CdseStacItemAccessor,
-    Sen3CdseStacItemAccessor,
-    Sen2CdseStacArdcAccessor,
-    Sen3CdseStacArdcAccessor,
-    Sen2PlanetaryComputerStacItemAccessor,
-    Sen2PlanetaryComputerStacArdcAccessor,
-)
-from xcube_stac.constants import (
-    DATA_STORE_ID_CDSE,
-    DATA_STORE_ID_CDSE_ARDC,
-    DATA_STORE_ID_PC,
-    DATA_STORE_ID_PC_ARDC,
-)
+from xcube_stac.accessors import (BaseStacItemAccessor,
+                                  Sen2CdseStacArdcAccessor,
+                                  Sen2CdseStacItemAccessor,
+                                  Sen2PlanetaryComputerStacArdcAccessor,
+                                  Sen2PlanetaryComputerStacItemAccessor,
+                                  Sen3CdseStacArdcAccessor,
+                                  Sen3CdseStacItemAccessor,
+                                  guess_ardc_accessor, guess_item_accessor,
+                                  list_ardc_data_ids)
+from xcube_stac.constants import (DATA_STORE_ID_CDSE, DATA_STORE_ID_CDSE_ARDC,
+                                  DATA_STORE_ID_PC, DATA_STORE_ID_PC_ARDC)
 
 
 class AccessorInitTest(unittest.TestCase):

--- a/test/accessor/test_base.py
+++ b/test/accessor/test_base.py
@@ -21,12 +21,13 @@
 
 import unittest
 from unittest.mock import patch
-import xarray as xr
+
 import numpy as np
 import pystac
+import xarray as xr
 from xcube.core.store import DataStore
 
-from xcube_stac.accessors.base import BaseStacItemAccessor, XcubeStacItemAccessor
+from xcube_stac.accessors.base import (BaseStacItemAccessor)
 
 
 class BaseStacItemAccessorTest(unittest.TestCase):

--- a/test/accessor/test_base.py
+++ b/test/accessor/test_base.py
@@ -27,7 +27,7 @@ import pystac
 import xarray as xr
 from xcube.core.store import DataStore
 
-from xcube_stac.accessors.base import (BaseStacItemAccessor)
+from xcube_stac.accessors.base import BaseStacItemAccessor
 
 
 class BaseStacItemAccessorTest(unittest.TestCase):

--- a/test/accessor/test_base.py
+++ b/test/accessor/test_base.py
@@ -31,7 +31,6 @@ from xcube_stac.accessors.base import BaseStacItemAccessor
 
 
 class BaseStacItemAccessorTest(unittest.TestCase):
-
     def setUp(self):
         self.catalog = pystac.Catalog(
             id="test-catalog",

--- a/test/stac_extension/test_raster.py
+++ b/test/stac_extension/test_raster.py
@@ -26,8 +26,7 @@ import numpy as np
 import pystac
 import xarray as xr
 
-from xcube_stac.stac_extension.raster import (apply_offset_scaling,
-                                              get_stac_extension)
+from xcube_stac.stac_extension.raster import apply_offset_scaling, get_stac_extension
 
 
 def create_raster_stac_item_v1() -> pystac.Item:
@@ -93,7 +92,6 @@ def create_raster_stac_item_v2() -> pystac.Item:
 
 
 class RasterTest(unittest.TestCase):
-
     def test_get_stac_extension(self):
         item_v1 = create_raster_stac_item_v1()
         self.assertEqual("v1", get_stac_extension(item_v1))

--- a/test/test_href_parse.py
+++ b/test/test_href_parse.py
@@ -23,12 +23,14 @@ import unittest
 
 from xcube.core.store import DataStoreError
 
-from xcube_stac.href_parse import (assert_aws_s3_bucket,
-                                   assert_aws_s3_region_name, decode_href)
+from xcube_stac.href_parse import (
+    assert_aws_s3_bucket,
+    assert_aws_s3_region_name,
+    decode_href,
+)
 
 
 class HrefParseTest(unittest.TestCase):
-
     def test_decode_href(self):
         hrefs = [
             "https://s3.amazonaws.com/bucket-name/filename",

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -27,19 +27,32 @@ from unittest.mock import patch
 import pytest
 import xarray as xr
 from xcube.core.mldataset import MultiLevelDataset
-from xcube.core.store import (DatasetDescriptor, DataStoreError,
-                              MultiLevelDatasetDescriptor, new_data_store)
+from xcube.core.store import (
+    DatasetDescriptor,
+    DataStoreError,
+    MultiLevelDatasetDescriptor,
+    new_data_store,
+)
 from xcube.util.jsonschema import JsonComplexSchema, JsonObjectSchema
 
 # noinspection PyProtectedMember
 from xcube_stac.accessors.sen2 import _SENTINEL2_L2A_BANDS
-from xcube_stac.constants import (DATA_STORE_ID, DATA_STORE_ID_CDSE,
-                                  DATA_STORE_ID_CDSE_ARDC, DATA_STORE_ID_PC,
-                                  DATA_STORE_ID_PC_ARDC, DATA_STORE_ID_XCUBE)
+from xcube_stac.constants import (
+    DATA_STORE_ID,
+    DATA_STORE_ID_CDSE,
+    DATA_STORE_ID_CDSE_ARDC,
+    DATA_STORE_ID_PC,
+    DATA_STORE_ID_PC_ARDC,
+    DATA_STORE_ID_XCUBE,
+)
 from xcube_stac.utils import reproject_bbox
 
-from .sampledata import (sentinel_2_band_data_10m, sentinel_2_band_data_60m,
-                         sentinel_3_data, sentinel_3_geolocation_data)
+from .sampledata import (
+    sentinel_2_band_data_10m,
+    sentinel_2_band_data_60m,
+    sentinel_3_data,
+    sentinel_3_geolocation_data,
+)
 
 SKIP_HELP = (
     "Skipped, because server is not running:"
@@ -67,7 +80,6 @@ XCUBE_SERVER_IS_RUNNING = is_server_running()
 
 
 class StacDataStoreTest(unittest.TestCase):
-
     def setUp(self):
         self.url_nonsearchable = (
             "https://raw.githubusercontent.com/stac-extensions/"

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -27,32 +27,19 @@ from unittest.mock import patch
 import pytest
 import xarray as xr
 from xcube.core.mldataset import MultiLevelDataset
-from xcube.core.store import (
-    DatasetDescriptor,
-    DataStoreError,
-    MultiLevelDatasetDescriptor,
-    new_data_store,
-)
-from xcube.util.jsonschema import JsonObjectSchema, JsonComplexSchema
+from xcube.core.store import (DatasetDescriptor, DataStoreError,
+                              MultiLevelDatasetDescriptor, new_data_store)
+from xcube.util.jsonschema import JsonComplexSchema, JsonObjectSchema
 
 # noinspection PyProtectedMember
 from xcube_stac.accessors.sen2 import _SENTINEL2_L2A_BANDS
-from xcube_stac.constants import (
-    DATA_STORE_ID,
-    DATA_STORE_ID_CDSE,
-    DATA_STORE_ID_PC,
-    DATA_STORE_ID_CDSE_ARDC,
-    DATA_STORE_ID_PC_ARDC,
-    DATA_STORE_ID_XCUBE,
-)
+from xcube_stac.constants import (DATA_STORE_ID, DATA_STORE_ID_CDSE,
+                                  DATA_STORE_ID_CDSE_ARDC, DATA_STORE_ID_PC,
+                                  DATA_STORE_ID_PC_ARDC, DATA_STORE_ID_XCUBE)
 from xcube_stac.utils import reproject_bbox
 
-from .sampledata import (
-    sentinel_2_band_data_10m,
-    sentinel_2_band_data_60m,
-    sentinel_3_data,
-    sentinel_3_geolocation_data,
-)
+from .sampledata import (sentinel_2_band_data_10m, sentinel_2_band_data_60m,
+                         sentinel_3_data, sentinel_3_geolocation_data)
 
 SKIP_HELP = (
     "Skipped, because server is not running:"

--- a/test/test_store.py
+++ b/test/test_store.py
@@ -33,7 +33,7 @@ from xcube.core.store import (
     MultiLevelDatasetDescriptor,
     new_data_store,
 )
-from xcube.util.jsonschema import JsonObjectSchema
+from xcube.util.jsonschema import JsonObjectSchema, JsonComplexSchema
 
 # noinspection PyProtectedMember
 from xcube_stac.accessors.sen2 import _SENTINEL2_L2A_BANDS
@@ -396,7 +396,7 @@ class StacDataStoreTest(unittest.TestCase):
         data_ids = ("sentinel-2-l2a", "sentinel-2-l1c", "sentinel-3-syn-2-syn-ntc")
         for data_id in data_ids:
             schema = store.get_open_data_params_schema(data_id=data_id)
-            self.assertIsInstance(schema, JsonObjectSchema)
+            self.assertIsInstance(schema, JsonSchema)
             self.assertIn("asset_names", schema.properties)
             self.assertIn("time_range", schema.properties)
             self.assertIn("bbox", schema.properties)
@@ -903,6 +903,7 @@ class StacDataStoreTest(unittest.TestCase):
             crs=crs_target,
             asset_names=["B04"],
             apply_scaling=True,
+            add_angles=True,
             add_angles=True,
         )
         self.assertIsInstance(ds, xr.Dataset)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -31,20 +31,31 @@ import requests
 import xarray as xr
 from xcube.core.store import DataStoreError
 
-from xcube_stac.utils import (access_collection, access_item,
-                              convert_datetime2str, convert_str2datetime,
-                              do_bboxes_intersect, get_format_from_path,
-                              get_format_id, get_grid_mapping_name,
-                              get_spatial_dims, is_collection_in_time_range,
-                              is_item_in_time_range, list_assets_from_item,
-                              merge_datasets, mosaic_spatial_take_first,
-                              normalize_crs, rename_dataset, reproject_bbox,
-                              search_collections, search_nonsearchable_catalog,
-                              update_dict)
+from xcube_stac.utils import (
+    access_collection,
+    access_item,
+    convert_datetime2str,
+    convert_str2datetime,
+    do_bboxes_intersect,
+    get_format_from_path,
+    get_format_id,
+    get_grid_mapping_name,
+    get_spatial_dims,
+    is_collection_in_time_range,
+    is_item_in_time_range,
+    list_assets_from_item,
+    merge_datasets,
+    mosaic_spatial_take_first,
+    normalize_crs,
+    rename_dataset,
+    reproject_bbox,
+    search_collections,
+    search_nonsearchable_catalog,
+    update_dict,
+)
 
 
 class UtilsTest(unittest.TestCase):
-
     def test_get_format_id(self):
         asset = pystac.Asset(
             href="https://example.com/data/test.tif",

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -21,7 +21,7 @@
 
 import datetime
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import dask.array as da
 import numpy as np
@@ -31,28 +31,16 @@ import requests
 import xarray as xr
 from xcube.core.store import DataStoreError
 
-from xcube_stac.utils import (
-    access_collection,
-    access_item,
-    convert_datetime2str,
-    convert_str2datetime,
-    do_bboxes_intersect,
-    get_format_from_path,
-    get_format_id,
-    get_grid_mapping_name,
-    get_spatial_dims,
-    is_collection_in_time_range,
-    is_item_in_time_range,
-    list_assets_from_item,
-    merge_datasets,
-    mosaic_spatial_take_first,
-    normalize_crs,
-    rename_dataset,
-    reproject_bbox,
-    search_collections,
-    search_nonsearchable_catalog,
-    update_dict,
-)
+from xcube_stac.utils import (access_collection, access_item,
+                              convert_datetime2str, convert_str2datetime,
+                              do_bboxes_intersect, get_format_from_path,
+                              get_format_id, get_grid_mapping_name,
+                              get_spatial_dims, is_collection_in_time_range,
+                              is_item_in_time_range, list_assets_from_item,
+                              merge_datasets, mosaic_spatial_take_first,
+                              normalize_crs, rename_dataset, reproject_bbox,
+                              search_collections, search_nonsearchable_catalog,
+                              update_dict)
 
 
 class UtilsTest(unittest.TestCase):

--- a/xcube_stac/accessors/__init__.py
+++ b/xcube_stac/accessors/__init__.py
@@ -22,19 +22,13 @@
 from typing import Type
 
 from xcube_stac.accessor import StacArdcAccessor, StacItemAccessor
-from xcube_stac.constants import (
-    DATA_STORE_ID_CDSE,
-    DATA_STORE_ID_CDSE_ARDC,
-    DATA_STORE_ID_PC,
-    DATA_STORE_ID_PC_ARDC,
-)
+from xcube_stac.constants import (DATA_STORE_ID_CDSE, DATA_STORE_ID_CDSE_ARDC,
+                                  DATA_STORE_ID_PC, DATA_STORE_ID_PC_ARDC)
+
 from .base import BaseStacItemAccessor
-from .sen2 import (
-    Sen2CdseStacArdcAccessor,
-    Sen2CdseStacItemAccessor,
-    Sen2PlanetaryComputerStacArdcAccessor,
-    Sen2PlanetaryComputerStacItemAccessor,
-)
+from .sen2 import (Sen2CdseStacArdcAccessor, Sen2CdseStacItemAccessor,
+                   Sen2PlanetaryComputerStacArdcAccessor,
+                   Sen2PlanetaryComputerStacItemAccessor)
 from .sen3 import Sen3CdseStacArdcAccessor, Sen3CdseStacItemAccessor
 
 ACCESSOR_MAPPING = {

--- a/xcube_stac/accessors/__init__.py
+++ b/xcube_stac/accessors/__init__.py
@@ -22,13 +22,20 @@
 from typing import Type
 
 from xcube_stac.accessor import StacArdcAccessor, StacItemAccessor
-from xcube_stac.constants import (DATA_STORE_ID_CDSE, DATA_STORE_ID_CDSE_ARDC,
-                                  DATA_STORE_ID_PC, DATA_STORE_ID_PC_ARDC)
+from xcube_stac.constants import (
+    DATA_STORE_ID_CDSE,
+    DATA_STORE_ID_CDSE_ARDC,
+    DATA_STORE_ID_PC,
+    DATA_STORE_ID_PC_ARDC,
+)
 
 from .base import BaseStacItemAccessor
-from .sen2 import (Sen2CdseStacArdcAccessor, Sen2CdseStacItemAccessor,
-                   Sen2PlanetaryComputerStacArdcAccessor,
-                   Sen2PlanetaryComputerStacItemAccessor)
+from .sen2 import (
+    Sen2CdseStacArdcAccessor,
+    Sen2CdseStacItemAccessor,
+    Sen2PlanetaryComputerStacArdcAccessor,
+    Sen2PlanetaryComputerStacItemAccessor,
+)
 from .sen3 import Sen3CdseStacArdcAccessor, Sen3CdseStacItemAccessor
 
 ACCESSOR_MAPPING = {

--- a/xcube_stac/accessors/base.py
+++ b/xcube_stac/accessors/base.py
@@ -30,13 +30,10 @@ from xcube.util.jsonschema import JsonObjectSchema
 from xcube_stac.accessor import StacItemAccessor
 from xcube_stac.constants import LOG, SCHEMA_APPLY_SCALING, SCHEMA_ASSET_NAMES
 from xcube_stac.href_parse import decode_href
-from xcube_stac.stac_extension.raster import apply_offset_scaling, get_stac_extension
-from xcube_stac.utils import (
-    list_assets_from_item,
-    normalize_grid_mapping,
-    rename_dataset,
-    update_dict,
-)
+from xcube_stac.stac_extension.raster import (apply_offset_scaling,
+                                              get_stac_extension)
+from xcube_stac.utils import (list_assets_from_item, normalize_grid_mapping,
+                              rename_dataset, update_dict)
 from xcube_stac.version import version
 
 

--- a/xcube_stac/accessors/base.py
+++ b/xcube_stac/accessors/base.py
@@ -30,10 +30,13 @@ from xcube.util.jsonschema import JsonObjectSchema
 from xcube_stac.accessor import StacItemAccessor
 from xcube_stac.constants import LOG, SCHEMA_APPLY_SCALING, SCHEMA_ASSET_NAMES
 from xcube_stac.href_parse import decode_href
-from xcube_stac.stac_extension.raster import (apply_offset_scaling,
-                                              get_stac_extension)
-from xcube_stac.utils import (list_assets_from_item, normalize_grid_mapping,
-                              rename_dataset, update_dict)
+from xcube_stac.stac_extension.raster import apply_offset_scaling, get_stac_extension
+from xcube_stac.utils import (
+    list_assets_from_item,
+    normalize_grid_mapping,
+    rename_dataset,
+    update_dict,
+)
 from xcube_stac.version import version
 
 

--- a/xcube_stac/accessors/sen2.py
+++ b/xcube_stac/accessors/sen2.py
@@ -38,38 +38,23 @@ import xmltodict
 from xcube.core.gridmapping import GridMapping
 from xcube.core.resampling import affine_transform_dataset, reproject_dataset
 from xcube.core.store import DataStoreError
-from xcube.util.jsonschema import (
-    JsonArraySchema,
-    JsonBooleanSchema,
-    JsonComplexSchema,
-    JsonNumberSchema,
-    JsonObjectSchema,
-    JsonStringSchema,
-)
+from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
+                                   JsonComplexSchema, JsonNumberSchema,
+                                   JsonObjectSchema, JsonStringSchema)
 
 from xcube_stac.accessor import StacArdcAccessor, StacItemAccessor
-from xcube_stac.constants import (
-    CONVERSION_FACTOR_DEG_METER,
-    SCHEMA_ADDITIONAL_QUERY,
-    SCHEMA_APPLY_SCALING,
-    SCHEMA_CRS,
-    SCHEMA_SPATIAL_RES,
-    SCHEMA_TIME_RANGE,
-    SCHEMA_TILE_SIZE,
-    TILE_SIZE,
-)
-from xcube_stac.stac_extension.raster import apply_offset_scaling, get_stac_extension
-from xcube_stac.utils import (
-    add_nominal_datetime,
-    get_gridmapping,
-    get_spatial_dims,
-    merge_datasets,
-    mosaic_spatial_take_first,
-    normalize_crs,
-    normalize_grid_mapping,
-    rename_dataset,
-    reproject_bbox,
-)
+from xcube_stac.constants import (CONVERSION_FACTOR_DEG_METER,
+                                  SCHEMA_ADDITIONAL_QUERY,
+                                  SCHEMA_APPLY_SCALING, SCHEMA_CRS,
+                                  SCHEMA_SPATIAL_RES, SCHEMA_TILE_SIZE,
+                                  SCHEMA_TIME_RANGE, TILE_SIZE)
+from xcube_stac.stac_extension.raster import (apply_offset_scaling,
+                                              get_stac_extension)
+from xcube_stac.utils import (add_nominal_datetime, get_gridmapping,
+                              get_spatial_dims, merge_datasets,
+                              mosaic_spatial_take_first, normalize_crs,
+                              normalize_grid_mapping, rename_dataset,
+                              reproject_bbox)
 from xcube_stac.version import version
 
 _SENTINEL2_BANDS = [
@@ -812,7 +797,7 @@ class Sen2PlanetaryComputerStacItemAccessor(Sen2CdseStacItemAccessor):
             response = requests.get(item.assets["product-metadata"].href)
             response.raise_for_status()
             xml_dict = xmltodict.parse(response.text)
-            info = xml_dict[f"n1:Level-2A_User_Product"]["n1:General_Info"][
+            info = xml_dict["n1:Level-2A_User_Product"]["n1:General_Info"][
                 "Product_Image_Characteristics"
             ]
             item.properties["xcube:offset_scaling"] = info

--- a/xcube_stac/accessors/sen2.py
+++ b/xcube_stac/accessors/sen2.py
@@ -516,12 +516,12 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
         )
         t = pyproj.Transformer.from_crs("EPSG:4326", crs_data, always_xy=True)
         point_data = t.transform(open_params["point"][0], open_params["point"][1])
-        bbox_hwidth = open_params["bbox_width"] / 2
+        bbox_width = open_params["bbox_width"] / 2
         bbox_data = [
-            point_data[0] - bbox_hwidth,
-            point_data[1] - bbox_hwidth,
-            point_data[0] + bbox_hwidth,
-            point_data[1] + bbox_hwidth,
+            point_data[0] - bbox_width,
+            point_data[1] - bbox_width,
+            point_data[0] + bbox_width,
+            point_data[1] + bbox_width,
         ]
         ds_final = ds_final.sel(
             x=slice(bbox_data[0], bbox_data[2]),

--- a/xcube_stac/accessors/sen2.py
+++ b/xcube_stac/accessors/sen2.py
@@ -38,23 +38,38 @@ import xmltodict
 from xcube.core.gridmapping import GridMapping
 from xcube.core.resampling import affine_transform_dataset, reproject_dataset
 from xcube.core.store import DataStoreError
-from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
-                                   JsonComplexSchema, JsonNumberSchema,
-                                   JsonObjectSchema, JsonStringSchema)
+from xcube.util.jsonschema import (
+    JsonArraySchema,
+    JsonBooleanSchema,
+    JsonComplexSchema,
+    JsonNumberSchema,
+    JsonObjectSchema,
+    JsonStringSchema,
+)
 
 from xcube_stac.accessor import StacArdcAccessor, StacItemAccessor
-from xcube_stac.constants import (CONVERSION_FACTOR_DEG_METER,
-                                  SCHEMA_ADDITIONAL_QUERY,
-                                  SCHEMA_APPLY_SCALING, SCHEMA_CRS,
-                                  SCHEMA_SPATIAL_RES, SCHEMA_TILE_SIZE,
-                                  SCHEMA_TIME_RANGE, TILE_SIZE)
-from xcube_stac.stac_extension.raster import (apply_offset_scaling,
-                                              get_stac_extension)
-from xcube_stac.utils import (add_nominal_datetime, get_gridmapping,
-                              get_spatial_dims, merge_datasets,
-                              mosaic_spatial_take_first, normalize_crs,
-                              normalize_grid_mapping, rename_dataset,
-                              reproject_bbox)
+from xcube_stac.constants import (
+    CONVERSION_FACTOR_DEG_METER,
+    SCHEMA_ADDITIONAL_QUERY,
+    SCHEMA_APPLY_SCALING,
+    SCHEMA_CRS,
+    SCHEMA_SPATIAL_RES,
+    SCHEMA_TILE_SIZE,
+    SCHEMA_TIME_RANGE,
+    TILE_SIZE,
+)
+from xcube_stac.stac_extension.raster import apply_offset_scaling, get_stac_extension
+from xcube_stac.utils import (
+    add_nominal_datetime,
+    get_gridmapping,
+    get_spatial_dims,
+    merge_datasets,
+    mosaic_spatial_take_first,
+    normalize_crs,
+    normalize_grid_mapping,
+    rename_dataset,
+    reproject_bbox,
+)
 from xcube_stac.version import version
 
 _SENTINEL2_BANDS = [
@@ -334,7 +349,6 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
         items: Sequence[pystac.Item],
         **open_params,
     ) -> xr.Dataset:
-
         # Remove items with incorrect bounding boxes in the CDSE Sentinel-2 L2A catalog.
         # This issue primarily affects tiles that cross the antimeridian and has been
         # reported as a catalog bug. A single Sentinel-2 tile spans approximately
@@ -359,9 +373,7 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
         # strings, and the values are lists of corresponding item IDs.
         ds.attrs["stac_item_ids"] = dict(
             {
-                dt.astype("datetime64[ms]")
-                .astype("O")
-                .isoformat(): [
+                dt.astype("datetime64[ms]").astype("O").isoformat(): [
                     item.id for item in np.sum(grouped_items.sel(time=dt).values)
                 ]
                 for dt in grouped_items.time.values
@@ -454,7 +466,6 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
     def _generate_cube_single_tile(
         self, grouped_items: xr.DataArray, **open_params
     ) -> xr.Dataset:
-
         # find tile closest to the given point
         centers = np.zeros((2, grouped_items.sizes["tile_id"]))
         for idx_tile_id in range(grouped_items.shape[1]):

--- a/xcube_stac/accessors/sen2.py
+++ b/xcube_stac/accessors/sen2.py
@@ -389,6 +389,7 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
         self, data_id: str = None, opener_id: str = None
     ) -> JsonObjectSchema:
         bbox_schema = JsonObjectSchema(
+            title="Open parameters to open via a user-defined bounding box.",
             properties=dict(
                 asset_names=_SCHEMA_ASSET_NAMES,
                 time_range=SCHEMA_TIME_RANGE,
@@ -404,6 +405,7 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
             additional_properties=False,
         )
         point_schema = JsonObjectSchema(
+            title="Open parameters to generate a cube cutout around a given `point`.",
             properties=dict(
                 asset_names=_SCHEMA_ASSET_NAMES,
                 time_range=SCHEMA_TIME_RANGE,
@@ -648,7 +650,7 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
             spatial_res=spatial_res,
             apply_scaling=open_params.get("apply_scaling", True),
             add_angles=False,
-            tile_size=open_params.get("tile_size"),
+            tile_size=open_params.get("tile_size", TILE_SIZE),
         )
         final_ds = None
         for dt_idx, dt in enumerate(grouped_items.time.values):
@@ -674,7 +676,7 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
                         items_bbox,
                         final_bbox,
                         spatial_res,
-                        tile_size=open_params.get("tile_size"),
+                        tile_size=open_params.get("tile_size", TILE_SIZE),
                     )
                 final_ds = _insert_tile_data(final_ds, mosaicked_ds, dt_idx)
 

--- a/xcube_stac/accessors/sen2.py
+++ b/xcube_stac/accessors/sen2.py
@@ -486,7 +486,7 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
             spatial_res=open_params.get("spatial_res", 10),
             apply_scaling=open_params.get("apply_scaling", True),
             add_angles=open_params.get("add_angles", False),
-            tile_size=open_params.get("tile_size"),
+            tile_size=open_params.get("tile_size", TILE_SIZE),
         )
         dss = []
         idx_remove_dt = []

--- a/xcube_stac/accessors/sen3.py
+++ b/xcube_stac/accessors/sen3.py
@@ -30,29 +30,16 @@ import shapely
 import xarray as xr
 from rasterio.errors import NotGeoreferencedWarning
 from xcube.core.resampling import rectify_dataset
-from xcube.util.jsonschema import (
-    JsonArraySchema,
-    JsonBooleanSchema,
-    JsonObjectSchema,
-    JsonStringSchema,
-)
+from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
+                                   JsonObjectSchema, JsonStringSchema)
 
 from xcube_stac.accessor import StacArdcAccessor, StacItemAccessor
-from xcube_stac.constants import (
-    SCHEMA_ADDITIONAL_QUERY,
-    SCHEMA_BBOX,
-    SCHEMA_CRS,
-    SCHEMA_SPATIAL_RES,
-    SCHEMA_TIME_RANGE,
-    TILE_SIZE,
-)
-from xcube_stac.utils import (
-    add_nominal_datetime,
-    get_gridmapping,
-    list_assets_from_item,
-    mosaic_spatial_take_first,
-    reproject_bbox,
-)
+from xcube_stac.constants import (SCHEMA_ADDITIONAL_QUERY, SCHEMA_BBOX,
+                                  SCHEMA_CRS, SCHEMA_SPATIAL_RES,
+                                  SCHEMA_TIME_RANGE, TILE_SIZE)
+from xcube_stac.utils import (add_nominal_datetime, get_gridmapping,
+                              list_assets_from_item, mosaic_spatial_take_first,
+                              reproject_bbox)
 
 _SENTINEL3_ASSETS = [
     "syn_S1N_reflectance",

--- a/xcube_stac/accessors/sen3.py
+++ b/xcube_stac/accessors/sen3.py
@@ -30,16 +30,29 @@ import shapely
 import xarray as xr
 from rasterio.errors import NotGeoreferencedWarning
 from xcube.core.resampling import rectify_dataset
-from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
-                                   JsonObjectSchema, JsonStringSchema)
+from xcube.util.jsonschema import (
+    JsonArraySchema,
+    JsonBooleanSchema,
+    JsonObjectSchema,
+    JsonStringSchema,
+)
 
 from xcube_stac.accessor import StacArdcAccessor, StacItemAccessor
-from xcube_stac.constants import (SCHEMA_ADDITIONAL_QUERY, SCHEMA_BBOX,
-                                  SCHEMA_CRS, SCHEMA_SPATIAL_RES,
-                                  SCHEMA_TIME_RANGE, TILE_SIZE)
-from xcube_stac.utils import (add_nominal_datetime, get_gridmapping,
-                              list_assets_from_item, mosaic_spatial_take_first,
-                              reproject_bbox)
+from xcube_stac.constants import (
+    SCHEMA_ADDITIONAL_QUERY,
+    SCHEMA_BBOX,
+    SCHEMA_CRS,
+    SCHEMA_SPATIAL_RES,
+    SCHEMA_TIME_RANGE,
+    TILE_SIZE,
+)
+from xcube_stac.utils import (
+    add_nominal_datetime,
+    get_gridmapping,
+    list_assets_from_item,
+    mosaic_spatial_take_first,
+    reproject_bbox,
+)
 
 _SENTINEL3_ASSETS = [
     "syn_S1N_reflectance",
@@ -192,7 +205,6 @@ class Sen3CdseStacArdcAccessor(Sen3CdseStacItemAccessor, StacArdcAccessor):
         items: Sequence[pystac.Item],
         **open_params,
     ) -> xr.Dataset:
-
         # filter items by checking if bounding box and polygon of tiles overlap
         items = _filter_items_spatial(items, open_params["bbox"])
 
@@ -208,9 +220,7 @@ class Sen3CdseStacArdcAccessor(Sen3CdseStacItemAccessor, StacArdcAccessor):
         # strings, and the values are lists of corresponding item IDs.
         ds.attrs["stac_item_ids"] = dict(
             {
-                dt.astype("datetime64[ms]")
-                .astype("O")
-                .isoformat(): [
+                dt.astype("datetime64[ms]").astype("O").isoformat(): [
                     item.id for item in np.sum(grouped_items.sel(time=dt).values)
                 ]
                 for dt in grouped_items.time.values

--- a/xcube_stac/constants.py
+++ b/xcube_stac/constants.py
@@ -22,9 +22,15 @@
 import logging
 
 from xcube.core.store.fs.impl.fs import S3FsAccessor
-from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
-                                   JsonDateSchema, JsonNumberSchema,
-                                   JsonObjectSchema, JsonStringSchema)
+from xcube.util.jsonschema import (
+    JsonArraySchema,
+    JsonBooleanSchema,
+    JsonDateSchema,
+    JsonNumberSchema,
+    JsonObjectSchema,
+    JsonStringSchema,
+    JsonComplexSchema,
+)
 
 # general stac constants
 DATA_STORE_ID = "stac"
@@ -44,7 +50,7 @@ PC_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"
 DATA_STORE_ID_XCUBE = "stac-xcube"
 
 # other constants
-TILE_SIZE = 2048
+TILE_SIZE = 1024
 LOG = logging.getLogger("xcube.stac")
 FloatInt = float | int
 CONVERSION_FACTOR_DEG_METER = 111320
@@ -135,3 +141,20 @@ SCHEMA_APPLY_SCALING = JsonBooleanSchema(
 )
 SCHEMA_SPATIAL_RES = JsonNumberSchema(title="Spatial Resolution", exclusive_minimum=0.0)
 SCHEMA_CRS = JsonStringSchema(title="Coordinate reference system", default="EPSG:4326")
+SCHEMA_TILE_SIZE = JsonComplexSchema(
+    title="Spatial chunk size",
+    description=(
+        "Either a tuple asigning width and height (x, y), "
+        "or single int for quadratic chunk size."
+    ),
+    one_of=[
+        JsonNumberSchema(exclusive_minimum=256),
+        JsonArraySchema(
+            items=(
+                JsonNumberSchema(exclusive_minimum=256),
+                JsonNumberSchema(exclusive_minimum=256),
+            )
+        ),
+    ],
+    default=1024,
+)

--- a/xcube_stac/constants.py
+++ b/xcube_stac/constants.py
@@ -22,10 +22,15 @@
 import logging
 
 from xcube.core.store.fs.impl.fs import S3FsAccessor
-from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
-                                   JsonComplexSchema, JsonDateSchema,
-                                   JsonNumberSchema, JsonObjectSchema,
-                                   JsonStringSchema)
+from xcube.util.jsonschema import (
+    JsonArraySchema,
+    JsonBooleanSchema,
+    JsonComplexSchema,
+    JsonDateSchema,
+    JsonNumberSchema,
+    JsonObjectSchema,
+    JsonStringSchema,
+)
 
 # general stac constants
 DATA_STORE_ID = "stac"

--- a/xcube_stac/constants.py
+++ b/xcube_stac/constants.py
@@ -156,5 +156,5 @@ SCHEMA_TILE_SIZE = JsonComplexSchema(
             )
         ),
     ],
-    default=1024,
+    default=TILE_SIZE,
 )

--- a/xcube_stac/constants.py
+++ b/xcube_stac/constants.py
@@ -148,11 +148,11 @@ SCHEMA_TILE_SIZE = JsonComplexSchema(
         "or single int for quadratic chunk size."
     ),
     one_of=[
-        JsonNumberSchema(exclusive_minimum=256),
+        JsonNumberSchema(minimum=256),
         JsonArraySchema(
             items=(
-                JsonNumberSchema(exclusive_minimum=256),
-                JsonNumberSchema(exclusive_minimum=256),
+                JsonNumberSchema(minimum=256),
+                JsonNumberSchema(minimum=256),
             )
         ),
     ],

--- a/xcube_stac/constants.py
+++ b/xcube_stac/constants.py
@@ -22,15 +22,10 @@
 import logging
 
 from xcube.core.store.fs.impl.fs import S3FsAccessor
-from xcube.util.jsonschema import (
-    JsonArraySchema,
-    JsonBooleanSchema,
-    JsonDateSchema,
-    JsonNumberSchema,
-    JsonObjectSchema,
-    JsonStringSchema,
-    JsonComplexSchema,
-)
+from xcube.util.jsonschema import (JsonArraySchema, JsonBooleanSchema,
+                                   JsonComplexSchema, JsonDateSchema,
+                                   JsonNumberSchema, JsonObjectSchema,
+                                   JsonStringSchema)
 
 # general stac constants
 DATA_STORE_ID = "stac"

--- a/xcube_stac/plugin.py
+++ b/xcube_stac/plugin.py
@@ -22,14 +22,9 @@
 from xcube.constants import EXTENSION_POINT_DATA_STORES
 from xcube.util import extension
 
-from .constants import (
-    DATA_STORE_ID,
-    DATA_STORE_ID_CDSE,
-    DATA_STORE_ID_CDSE_ARDC,
-    DATA_STORE_ID_PC,
-    DATA_STORE_ID_PC_ARDC,
-    DATA_STORE_ID_XCUBE,
-)
+from .constants import (DATA_STORE_ID, DATA_STORE_ID_CDSE,
+                        DATA_STORE_ID_CDSE_ARDC, DATA_STORE_ID_PC,
+                        DATA_STORE_ID_PC_ARDC, DATA_STORE_ID_XCUBE)
 
 
 def init_plugin(ext_registry: extension.ExtensionRegistry):

--- a/xcube_stac/plugin.py
+++ b/xcube_stac/plugin.py
@@ -22,9 +22,14 @@
 from xcube.constants import EXTENSION_POINT_DATA_STORES
 from xcube.util import extension
 
-from .constants import (DATA_STORE_ID, DATA_STORE_ID_CDSE,
-                        DATA_STORE_ID_CDSE_ARDC, DATA_STORE_ID_PC,
-                        DATA_STORE_ID_PC_ARDC, DATA_STORE_ID_XCUBE)
+from .constants import (
+    DATA_STORE_ID,
+    DATA_STORE_ID_CDSE,
+    DATA_STORE_ID_CDSE_ARDC,
+    DATA_STORE_ID_PC,
+    DATA_STORE_ID_PC_ARDC,
+    DATA_STORE_ID_XCUBE,
+)
 
 
 def init_plugin(ext_registry: extension.ExtensionRegistry):

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -29,29 +29,57 @@ import pystac_client
 import requests
 import xarray as xr
 from xcube.core.mldataset import MultiLevelDataset
-from xcube.core.store import (DATASET_TYPE, MULTI_LEVEL_DATASET_TYPE,
-                              DatasetDescriptor, DataStore, DataStoreError,
-                              DataType, DataTypeLike,
-                              MultiLevelDatasetDescriptor)
+from xcube.core.store import (
+    DATASET_TYPE,
+    MULTI_LEVEL_DATASET_TYPE,
+    DatasetDescriptor,
+    DataStore,
+    DataStoreError,
+    DataType,
+    DataTypeLike,
+    MultiLevelDatasetDescriptor,
+)
 from xcube.util.jsonschema import JsonObjectSchema, JsonStringSchema
 
-from .accessors import (guess_ardc_accessor, guess_item_accessor,
-                        list_ardc_data_ids)
+from .accessors import guess_ardc_accessor, guess_item_accessor, list_ardc_data_ids
 from .accessors.base import XcubeStacItemAccessor
-from .constants import (CDSE_S3_ENDPOINT, CDSE_STAC_URL, DATA_OPENER_IDS,
-                        DATA_STORE_ID, DATA_STORE_ID_CDSE,
-                        DATA_STORE_ID_CDSE_ARDC, DATA_STORE_ID_PC,
-                        DATA_STORE_ID_PC_ARDC, DATA_STORE_ID_XCUBE, LOG,
-                        MAP_FILE_EXTENSION_FORMAT, PC_STAC_URL, PROTOCOLS,
-                        SCHEMA_ADDITIONAL_QUERY, SCHEMA_BBOX,
-                        SCHEMA_COLLECTIONS, SCHEMA_S3_STORE, SCHEMA_TIME_RANGE,
-                        SCHEMA_URL)
-from .utils import (access_collection, access_item, convert_datetime2str,
-                    get_attrs_from_pystac_object,
-                    get_data_id_from_pystac_object, is_mldataset_available,
-                    is_valid_ml_data_type, list_format_ids, list_protocols,
-                    modify_catalog_url, reproject_bbox, search_collections,
-                    search_items, update_dict)
+from .constants import (
+    CDSE_S3_ENDPOINT,
+    CDSE_STAC_URL,
+    DATA_OPENER_IDS,
+    DATA_STORE_ID,
+    DATA_STORE_ID_CDSE,
+    DATA_STORE_ID_CDSE_ARDC,
+    DATA_STORE_ID_PC,
+    DATA_STORE_ID_PC_ARDC,
+    DATA_STORE_ID_XCUBE,
+    LOG,
+    MAP_FILE_EXTENSION_FORMAT,
+    PC_STAC_URL,
+    PROTOCOLS,
+    SCHEMA_ADDITIONAL_QUERY,
+    SCHEMA_BBOX,
+    SCHEMA_COLLECTIONS,
+    SCHEMA_S3_STORE,
+    SCHEMA_TIME_RANGE,
+    SCHEMA_URL,
+)
+from .utils import (
+    access_collection,
+    access_item,
+    convert_datetime2str,
+    get_attrs_from_pystac_object,
+    get_data_id_from_pystac_object,
+    is_mldataset_available,
+    is_valid_ml_data_type,
+    list_format_ids,
+    list_protocols,
+    modify_catalog_url,
+    reproject_bbox,
+    search_collections,
+    search_items,
+    update_dict,
+)
 from .version import version
 
 

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -29,57 +29,29 @@ import pystac_client
 import requests
 import xarray as xr
 from xcube.core.mldataset import MultiLevelDataset
-from xcube.core.store import (
-    DATASET_TYPE,
-    MULTI_LEVEL_DATASET_TYPE,
-    DatasetDescriptor,
-    DataStore,
-    DataStoreError,
-    DataType,
-    DataTypeLike,
-    MultiLevelDatasetDescriptor,
-)
+from xcube.core.store import (DATASET_TYPE, MULTI_LEVEL_DATASET_TYPE,
+                              DatasetDescriptor, DataStore, DataStoreError,
+                              DataType, DataTypeLike,
+                              MultiLevelDatasetDescriptor)
 from xcube.util.jsonschema import JsonObjectSchema, JsonStringSchema
 
-from .accessors import guess_ardc_accessor, guess_item_accessor, list_ardc_data_ids
+from .accessors import (guess_ardc_accessor, guess_item_accessor,
+                        list_ardc_data_ids)
 from .accessors.base import XcubeStacItemAccessor
-from .constants import (
-    CDSE_S3_ENDPOINT,
-    CDSE_STAC_URL,
-    DATA_OPENER_IDS,
-    DATA_STORE_ID,
-    DATA_STORE_ID_CDSE,
-    DATA_STORE_ID_CDSE_ARDC,
-    DATA_STORE_ID_PC,
-    DATA_STORE_ID_PC_ARDC,
-    DATA_STORE_ID_XCUBE,
-    LOG,
-    MAP_FILE_EXTENSION_FORMAT,
-    PC_STAC_URL,
-    PROTOCOLS,
-    SCHEMA_ADDITIONAL_QUERY,
-    SCHEMA_BBOX,
-    SCHEMA_COLLECTIONS,
-    SCHEMA_S3_STORE,
-    SCHEMA_TIME_RANGE,
-    SCHEMA_URL,
-)
-from .utils import (
-    access_collection,
-    access_item,
-    convert_datetime2str,
-    get_attrs_from_pystac_object,
-    get_data_id_from_pystac_object,
-    is_mldataset_available,
-    is_valid_ml_data_type,
-    list_format_ids,
-    list_protocols,
-    modify_catalog_url,
-    reproject_bbox,
-    search_collections,
-    search_items,
-    update_dict,
-)
+from .constants import (CDSE_S3_ENDPOINT, CDSE_STAC_URL, DATA_OPENER_IDS,
+                        DATA_STORE_ID, DATA_STORE_ID_CDSE,
+                        DATA_STORE_ID_CDSE_ARDC, DATA_STORE_ID_PC,
+                        DATA_STORE_ID_PC_ARDC, DATA_STORE_ID_XCUBE, LOG,
+                        MAP_FILE_EXTENSION_FORMAT, PC_STAC_URL, PROTOCOLS,
+                        SCHEMA_ADDITIONAL_QUERY, SCHEMA_BBOX,
+                        SCHEMA_COLLECTIONS, SCHEMA_S3_STORE, SCHEMA_TIME_RANGE,
+                        SCHEMA_URL)
+from .utils import (access_collection, access_item, convert_datetime2str,
+                    get_attrs_from_pystac_object,
+                    get_data_id_from_pystac_object, is_mldataset_available,
+                    is_valid_ml_data_type, list_format_ids, list_protocols,
+                    modify_catalog_url, reproject_bbox, search_collections,
+                    search_items, update_dict)
 from .version import version
 
 

--- a/xcube_stac/store.py
+++ b/xcube_stac/store.py
@@ -575,15 +575,21 @@ class ArdcStacCdseDataStore(StacCdseDataStore):
         schema.validate_instance(open_params)
 
         # search for items
-        bbox_wgs84 = reproject_bbox(
-            open_params["bbox"], open_params["crs"], "EPSG:4326"
-        )
+        if "point" in open_params:
+            bbox_wgs84 = None
+            point_geojson = {"type": "Point", "coordinates": open_params["point"]}
+        else:
+            bbox_wgs84 = reproject_bbox(
+                open_params["bbox"], open_params["crs"], "EPSG:4326"
+            )
+            point_geojson = None
         items = list(
             search_items(
                 self._catalog,
                 self._searchable,
                 collections=[data_id],
                 bbox=bbox_wgs84,
+                intersects=point_geojson,
                 time_range=open_params["time_range"],
                 query=open_params.get("query"),
             )

--- a/xcube_stac/utils.py
+++ b/xcube_stac/utils.py
@@ -829,6 +829,13 @@ def get_spatial_dims(ds: xr.Dataset) -> (str, str):
     return y_coord, x_coord
 
 
+def _get_tile_size(open_params: dict) -> tuple[int, int]:
+    tile_size = open_params.get("tile_size", TILE_SIZE)
+    if isinstance(tile_size, int):
+        tile_size = (tile_size, tile_size)
+    return tile_size
+
+
 def _update_datasets(datasets: list[xr.Dataset]) -> xr.Dataset:
     ds = datasets[0].copy()
     for ds_asset in datasets[1:]:

--- a/xcube_stac/utils.py
+++ b/xcube_stac/utils.py
@@ -40,16 +40,11 @@ from shapely.geometry import box
 from xcube.core.gridmapping import GridMapping
 from xcube.core.gridmapping.dataset import new_grid_mapping_from_dataset
 from xcube.core.resampling import affine_transform_dataset
-from xcube.core.store import MULTI_LEVEL_DATASET_TYPE, DataStoreError, DataTypeLike
+from xcube.core.store import (MULTI_LEVEL_DATASET_TYPE, DataStoreError,
+                              DataTypeLike)
 
-from .constants import (
-    LOG,
-    MAP_FILE_EXTENSION_FORMAT,
-    MAP_MIME_TYP_FORMAT,
-    MLDATASET_FORMATS,
-    TILE_SIZE,
-    FloatInt,
-)
+from .constants import (LOG, MAP_FILE_EXTENSION_FORMAT, MAP_MIME_TYP_FORMAT,
+                        MLDATASET_FORMATS, TILE_SIZE, FloatInt)
 from .href_parse import decode_href
 
 _CATALOG_JSON = "catalog.json"

--- a/xcube_stac/utils.py
+++ b/xcube_stac/utils.py
@@ -40,11 +40,16 @@ from shapely.geometry import box
 from xcube.core.gridmapping import GridMapping
 from xcube.core.gridmapping.dataset import new_grid_mapping_from_dataset
 from xcube.core.resampling import affine_transform_dataset
-from xcube.core.store import (MULTI_LEVEL_DATASET_TYPE, DataStoreError,
-                              DataTypeLike)
+from xcube.core.store import MULTI_LEVEL_DATASET_TYPE, DataStoreError, DataTypeLike
 
-from .constants import (LOG, MAP_FILE_EXTENSION_FORMAT, MAP_MIME_TYP_FORMAT,
-                        MLDATASET_FORMATS, TILE_SIZE, FloatInt)
+from .constants import (
+    LOG,
+    MAP_FILE_EXTENSION_FORMAT,
+    MAP_MIME_TYP_FORMAT,
+    MLDATASET_FORMATS,
+    TILE_SIZE,
+    FloatInt,
+)
 from .href_parse import decode_href
 
 _CATALOG_JSON = "catalog.json"


### PR DESCRIPTION
A new mode was added that generates a time series cube from a single Sentinel-2 tile. Instead of providing `bbox` and `crs`, you now supply a `point` (lon, lat) together with a `bbox_width` in meters (must be < 10,000). The system will cut out a region around the given point, restricted to a single tile and native crs, and stack it along the time dimension. This improves cube generation performance.  

I have applied `isort` and `ruff`, which made some changes to the import. 