### PR TITLE
Time alignment for merging multiple UTM zones

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ## Changes in 1.3.3 (under development)
 
 - Fixed an issue with mosaicking the Harmonized Landsat Sentinel-2 (HLS) dataset (#59).
+- Fixed an issue when requesting a bounding box spanning multiple UTM zones, which
+  resulted in cubes with inconsistent time axes. The affected cubes now have their
+  temporal dimensions properly aligned during merging.
 
 ## Changes in 1.3.2
 

--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ Currently, we support the following collections and data IDs:
 - [`hls2-l30`](https://planetarycomputer.microsoft.com/dataset/hls2-l30)
 - [`hls2-s30`](https://planetarycomputer.microsoft.com/dataset/hls2-s30)
 
+> **Note:** The `hls2-l30` and `hls2-s30` products may contain tile gaps. Tiles 
+> located entirely outside the shoreline are not processed by the HLS processor 
+> [reference](https://lpdaac.usgs.gov/documents/1698/HLS_User_Guide_V2.pdf). 
+> Additionally, tiles with a mean solar zenith angle greater than 76° are filtered
+> out [reference](https://www.sciencedirect.com/science/article/pii/S0034425725001270?ref=pdf_download&fr=RR-2&rr=a144e7390dde7552). 
+> Tiles consisting entirely of cloud-covered pixels may also be removed if the HLS
+> processing workflow fails to generate a valid product.
+
 ---
 
 ## Setup

--- a/xcube_stac/accessors/hls.py
+++ b/xcube_stac/accessors/hls.py
@@ -244,7 +244,11 @@ class Sen2HlsStacItemAccessor(StacItemAccessor):
             bbox=bbox, xy_res=spatial_res, crs=crs, tile_size=tile_size
         )
         return resample_in_space(
-            ds, source_gm=source_gm, target_gm=target_gm, prevent_nan_propagations=True
+            ds,
+            source_gm=source_gm,
+            target_gm=target_gm,
+            prevent_nan_propagations=True,
+            fill_values={"Fmask": 255},
         )
 
     @staticmethod
@@ -469,7 +473,7 @@ class Sen2HlsStacArdcAccessor(Sen2HlsStacItemAccessor, StacArdcAccessor):
         var_ref = var_names[0]
         if var_names[0] == "Fmask":
             if len(var_names) == 1:
-                fill_value = 0
+                fill_value = 255
             else:
                 var_ref = var_names[1]
         dss = []
@@ -504,6 +508,7 @@ class Sen2HlsStacArdcAccessor(Sen2HlsStacItemAccessor, StacArdcAccessor):
             x=slice(final_bbox[0], final_bbox[2]),
             y=slice(final_bbox[3], final_bbox[1]),
         )
+        ds_final = ds_final.reindex(time=grouped_items.time, fill_value={"Fmask": 255})
 
         return ds_final
 
@@ -609,7 +614,12 @@ def _merge_utm_zones(list_ds_utm: list[xr.Dataset], **open_params) -> xr.Dataset
     resampled_list_ds = []
     for ds in list_ds_utm:
         resampled_list_ds.append(
-            resample_in_space(ds, target_gm=target_gm, prevent_nan_propagations=True)
+            resample_in_space(
+                ds,
+                target_gm=target_gm,
+                prevent_nan_propagations=True,
+                fill_values={"Fmask": 255},
+            )
         )
 
     var_names = list(resampled_list_ds[0].keys())
@@ -617,7 +627,7 @@ def _merge_utm_zones(list_ds_utm: list[xr.Dataset], **open_params) -> xr.Dataset
     fill_value = np.nan
     if var_names[0] == "Fmask":
         if len(var_names) == 1:
-            fill_value = 0
+            fill_value = 255
         else:
             var_ref = var_names[1]
 


### PR DESCRIPTION
Closes #61 

- Fixed an issue when requesting a bounding box spanning multiple UTM zones, which
  resulted in cubes with inconsistent time axes. The affected cubes now have their
  temporal dimensions properly aligned during merging.

