### PR TITLE
Correct time encoding in ARDC requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Changes in 1.3.3 (under development)
 
+- Set the correct time-axis encoding for ARDC requests, mitigating Zarr serialization
+  warnings during data writing.
 - Fixed an issue in Sentinel-2 time series cube generation (single-tile mode) where 
   the first timestamp could be empty if the requested point was assigned to a 
   neighboring tile. The first available observation for the selected tile is now 

--- a/xcube_stac/accessors/hls.py
+++ b/xcube_stac/accessors/hls.py
@@ -311,6 +311,11 @@ class Sen2HlsStacArdcAccessor(Sen2HlsStacItemAccessor, StacArdcAccessor):
                 for dt in grouped_items.time.values
             }
         )
+        ds["time"].encoding = {
+            "units": "days since 1970-01-01T00:00:00",
+            "calendar": "standard",
+            "dtype": "float32",
+        }
 
         return ds
 
@@ -431,9 +436,6 @@ class Sen2HlsStacArdcAccessor(Sen2HlsStacItemAccessor, StacArdcAccessor):
         grouped_items = grouped_items.assign_coords(
             time=np.array(dts, dtype="datetime64[ns]")
         )
-        grouped_items = grouped_items.assign_coords(time=dts)
-        grouped_items["time"].encoding["units"] = "seconds since 1970-01-01"
-        grouped_items["time"].encoding["calendar"] = "standard"
 
         return grouped_items
 

--- a/xcube_stac/accessors/sen2.py
+++ b/xcube_stac/accessors/sen2.py
@@ -392,6 +392,11 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
                 for dt in grouped_items.time.values
             }
         )
+        ds["time"].encoding = {
+            "units": "days since 1970-01-01T00:00:00",
+            "calendar": "standard",
+            "dtype": "float32",
+        }
 
         return ds
 
@@ -639,9 +644,6 @@ class Sen2CdseStacArdcAccessor(Sen2CdseStacItemAccessor, StacArdcAccessor):
         grouped_items = grouped_items.assign_coords(
             time=np.array(dts, dtype="datetime64[ns]")
         )
-        grouped_items = grouped_items.assign_coords(time=dts)
-        grouped_items["time"].encoding["units"] = "seconds since 1970-01-01"
-        grouped_items["time"].encoding["calendar"] = "standard"
 
         return grouped_items
 

--- a/xcube_stac/accessors/sen3.py
+++ b/xcube_stac/accessors/sen3.py
@@ -374,6 +374,12 @@ class Sen3CdseStacArdcAccessor(Sen3CdseStacItemAccessor, StacArdcAccessor):
             }
         )
 
+        ds["time"].encoding = {
+            "units": "days since 1970-01-01T00:00:00",
+            "calendar": "standard",
+            "dtype": "float32",
+        }
+
         return ds
 
     def get_open_data_params_schema(
@@ -561,9 +567,6 @@ def _group_items(items: list[pystac.Item]) -> xr.DataArray:
         dts[i] = mean_time.astype("datetime64[s]")
 
     array = xr.DataArray(grouped_items, dims=("time",), coords=dict(time=dts))
-
-    array["time"].encoding["units"] = "seconds since 1970-01-01"
-    array["time"].encoding["calendar"] = "standard"
 
     return array
 


### PR DESCRIPTION
- Set the correct time-axis encoding for ARDC requests, mitigating Zarr serialization
  warnings during data writing.